### PR TITLE
chore(docs): standardize README and csproj across projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
 		<EnableWindowsTargeting>true</EnableWindowsTargeting>
 		<Company>Hidden Worlds Games</Company>
 		<Product>Gondwana Game Engine</Product>
-		<Authors>Michael Adkins</Authors>
+		<Authors>Mike Adkins</Authors>
 
 		<!-- License -->
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -12,6 +12,7 @@
 
 		<!-- Symbols / Source Link -->
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
 
 		<!-- XML docs -->
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -20,24 +21,6 @@
 		<!-- Disable Android workload auto-import to avoid SDK version mismatch issues -->
 		<DisableAndroidWorkload>true</DisableAndroidWorkload>
 		<DisableImplicitWorkloadImports>true</DisableImplicitWorkloadImports>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(IsPackable)' == 'true'">
-		<!-- Symbols / Source Link -->
-		<IncludeSymbols>true</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
-
-		<!-- Release notes -->
-		<PackageReleaseNotes>See GitHub Releases or CHANGELOG.md in the repository at https://github.com/Isthimius/Gondwana/ for full release notes.</PackageReleaseNotes>
-
-		<!-- NuGet packaging and assets -->
-		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-
-		<!-- URLs / repository -->
-		<RepositoryUrl>https://github.com/Isthimius/Gondwana</RepositoryUrl>
-		<RepositoryType>git</RepositoryType>
-		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,15 @@
+<Project>
+	<PropertyGroup Condition="'$(IsPackable)' == 'true'">
+		<!-- Symbols / Source Link -->
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
+		<!-- NuGet packaging and assets -->
+		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+
+		<!-- URLs / repository -->
+		<RepositoryUrl>https://github.com/Isthimius/Gondwana</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+	</PropertyGroup>
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,8 +1,8 @@
 <Project>
 	<PropertyGroup Condition="'$(IsPackable)' == 'true'">
-		<!-- Symbols / Source Link -->
-		<IncludeSymbols>true</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<!-- Symbols / Source Link — disabled for template packages (no compiled output to symbolize) -->
+		<IncludeSymbols Condition="'$(PackageType)' != 'Template'">true</IncludeSymbols>
+		<SymbolPackageFormat Condition="'$(PackageType)' != 'Template'">snupkg</SymbolPackageFormat>
 
 		<!-- NuGet packaging and assets -->
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/Gondwana.Audio.Browser/Gondwana.Audio.Browser.csproj
+++ b/Gondwana.Audio.Browser/Gondwana.Audio.Browser.csproj
@@ -17,6 +17,7 @@
         <PackageTags>game-engine gamedev csharp dotnet audio browser wasm webassembly html5 avalonia js-interop</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>gondwana-logo.png</PackageIcon>
+		<PackageReleaseNotes>Full changelog: https://github.com/Isthimius/Gondwana/blob/master/CHANGELOG.md</PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>
@@ -25,6 +26,7 @@
 
     <ItemGroup>
         <None Include="README.md" Pack="true" PackagePath="" />
+		<None Include="CHANGELOG.md" Pack="true" PackagePath="" />
         <None Include="..\gondwana-logo.png" Pack="true" PackagePath="" Link="gondwana-logo.png" />
         
         <!-- For NuGet: include JS as content -->

--- a/Gondwana.Audio.Browser/README.md
+++ b/Gondwana.Audio.Browser/README.md
@@ -99,15 +99,17 @@ protected override void OnStartEngine()
 
 ## Documentation
 
-- **Source Code**: https://github.com/isthimius/Gondwana
-- **Architecture & Guides**: https://github.com/isthimius/Gondwana/wiki
+-   **[Source Code](https://github.com/isthimius/Gondwana)**
+-   **[Architecture & Guides](https://github.com/isthimius/Gondwana/wiki)**
+-   **[API Reference (Doxygen)](https://isthimius.github.io/Gondwana/)**
+-   **[Release History](https://github.com/Isthimius/Gondwana/blob/master/Gondwana.Audio.Browser/CHANGELOG.md)**
 
 ## Related Packages
 
-- `Gondwana` — Core engine
-- `Gondwana.Hosting` — Engine bootstrapping and lifecycle
-- `Gondwana.Avalonia` — Avalonia platform support
-- `Gondwana.Avalonia.Hosting` — Avalonia hosting
+-   `Gondwana` --- Core engine
+-   `Gondwana.Blazor` --- Web assembly rendering and input adapters
+-   `Gondwana.Blazor.Hosting` --- Blazor-specific game host that integrates rendering and input into the Gondwana lifecycle
+-   `Gondwana.Hosting` --- Standard platform-agnostic scaffolding for initializing and running Gondwana games
 
 ## License
 

--- a/Gondwana.Audio.Midi/Gondwana.Audio.Midi.csproj
+++ b/Gondwana.Audio.Midi/Gondwana.Audio.Midi.csproj
@@ -16,6 +16,7 @@
         <PackageTags>game-engine gamedev csharp dotnet audio midi adapter playback music sound</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageIcon>gondwana-logo.png</PackageIcon>
+		<PackageReleaseNotes>Full changelog: https://github.com/Isthimius/Gondwana/blob/master/CHANGELOG.md</PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>
@@ -33,6 +34,7 @@
 
 	<ItemGroup>
 		<None Include="README.md" Pack="true" PackagePath="" />
+		<None Include="CHANGELOG.md" Pack="true" PackagePath="" />
 		<None Include="..\gondwana-logo.png" Pack="true" PackagePath="" Link="gondwana-logo.png" />
 	</ItemGroup>
 

--- a/Gondwana.Audio.Midi/README.md
+++ b/Gondwana.Audio.Midi/README.md
@@ -28,19 +28,15 @@ host.Engine.InitializeMidiAudioFormats();
 
 ## Documentation
 
--   **Source Code**\
-    https://github.com/isthimius/Gondwana
-
--   **Architecture & Guides**\
-    https://github.com/isthimius/Gondwana/wiki
-
--   **API Reference (Doxygen)**\
-    https://isthimius.github.io/Gondwana/
+-   **[Source Code](https://github.com/isthimius/Gondwana)**
+-   **[Architecture & Guides](https://github.com/isthimius/Gondwana/wiki)**
+-   **[API Reference (Doxygen)](https://isthimius.github.io/Gondwana/)**
+-   **[Release History](https://github.com/Isthimius/Gondwana/blob/master/Gondwana.Audio.Midi/CHANGELOG.md)**
 
 ## Related Packages
 
-- `Gondwana` — Core engine
-- `Gondwana.Hosting` — Engine bootstrapping and lifecycle
+-   `Gondwana` --- Core engine
+-   `Gondwana.Hosting` --- Standard platform-agnostic scaffolding for initializing and running Gondwana games
 
 ## License
 

--- a/Gondwana.Avalonia.Hosting/Gondwana.Avalonia.Hosting.csproj
+++ b/Gondwana.Avalonia.Hosting/Gondwana.Avalonia.Hosting.csproj
@@ -16,6 +16,7 @@
         <PackageTags>game-engine gamedev csharp dotnet avalonia hosting cross-platform desktop wasm android ios macos bootstrap lifecycle game-loop initialization engine-host</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>gondwana-logo.png</PackageIcon>
+		<PackageReleaseNotes>Full changelog: https://github.com/Isthimius/Gondwana/blob/master/CHANGELOG.md</PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>
@@ -26,6 +27,7 @@
 
     <ItemGroup>
         <None Include="README.md" Pack="true" PackagePath="" />
+		<None Include="CHANGELOG.md" Pack="true" PackagePath="" />
         <None Include="..\gondwana-logo.png" Pack="true" PackagePath="" Link="gondwana-logo.png" />
     </ItemGroup>
 

--- a/Gondwana.Avalonia.Hosting/README.md
+++ b/Gondwana.Avalonia.Hosting/README.md
@@ -38,19 +38,16 @@ _host.Initialize();
 
 ## Documentation
 
--   **Source Code**\
-    https://github.com/isthimius/Gondwana
-
--   **Architecture & Guides**\
-    https://github.com/isthimius/Gondwana/wiki
-
--   **API Reference (Doxygen)**\
-    https://isthimius.github.io/Gondwana/
+-   **[Source Code](https://github.com/isthimius/Gondwana)**
+-   **[Architecture & Guides](https://github.com/isthimius/Gondwana/wiki)**
+-   **[API Reference (Doxygen)](https://isthimius.github.io/Gondwana/)**
+-   **[Release History](https://github.com/Isthimius/Gondwana/blob/master/Gondwana.Avalonia.Hosting/CHANGELOG.md)**
 
 ## Related Packages
 
-- `Gondwana` – Core engine
-- `Gondwana.Avalonia` – Avalonia platform adapters
+-   `Gondwana` --- Core engine
+-   `Gondwana.Avalonia` --- Avalonia rendering and input adapters
+-   `Gondwana.Hosting` --- Standard platform-agnostic scaffolding for initializing and running Gondwana games
 
 ## License
 

--- a/Gondwana.Avalonia/Gondwana.Avalonia.csproj
+++ b/Gondwana.Avalonia/Gondwana.Avalonia.csproj
@@ -19,6 +19,7 @@
         <PackageTags>game-engine gamedev csharp dotnet avalonia cross-platform desktop wasm android ios macos rendering input</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>gondwana-logo.png</PackageIcon>
+		<PackageReleaseNotes>Full changelog: https://github.com/Isthimius/Gondwana/blob/master/CHANGELOG.md</PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>
@@ -31,6 +32,7 @@
 
     <ItemGroup>
         <None Include="README.md" Pack="true" PackagePath="" />
+		<None Include="CHANGELOG.md" Pack="true" PackagePath="" />
         <None Include="..\gondwana-logo.png" Pack="true" PackagePath="" Link="gondwana-logo.png" />
     </ItemGroup>
 

--- a/Gondwana.Avalonia/README.md
+++ b/Gondwana.Avalonia/README.md
@@ -82,19 +82,15 @@ pinch.PinchUpdated += (_, e) => Console.WriteLine($"Pinch scale delta: {e.ScaleD
 
 ## Documentation
 
--   **Source Code**\
-    https://github.com/isthimius/Gondwana
-
--   **Architecture & Guides**\
-    https://github.com/isthimius/Gondwana/wiki
-
--   **API Reference (Doxygen)**\
-    https://isthimius.github.io/Gondwana/
+-   **[Source Code](https://github.com/isthimius/Gondwana)**
+-   **[Architecture & Guides](https://github.com/isthimius/Gondwana/wiki)**
+-   **[API Reference (Doxygen)](https://isthimius.github.io/Gondwana/)**
+-   **[Release History](https://github.com/Isthimius/Gondwana/blob/master/Gondwana.Avalonia/CHANGELOG.md)**
 
 ## Related Packages
 
-- `Gondwana` – Core engine
-- `Gondwana.Avalonia.Hosting` – Avalonia game host
+-   `Gondwana` --- Core engine
+-   `Gondwana.Avalonia.Hosting` --- Avalonia-specific game host that integrates rendering and input into the Gondwana lifecycle
 
 ## License
 

--- a/Gondwana.Blazor.Hosting/Gondwana.Blazor.Hosting.csproj
+++ b/Gondwana.Blazor.Hosting/Gondwana.Blazor.Hosting.csproj
@@ -16,6 +16,7 @@
         <PackageTags>game-engine gamedev csharp dotnet blazor wasm webassembly hosting bootstrap lifecycle game-loop initialization engine-host</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>gondwana-logo.png</PackageIcon>
+		<PackageReleaseNotes>Full changelog: https://github.com/Isthimius/Gondwana/blob/master/CHANGELOG.md</PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>
@@ -26,6 +27,7 @@
 
     <ItemGroup>
         <None Include="README.md" Pack="true" PackagePath="" />
+		<None Include="CHANGELOG.md" Pack="true" PackagePath="" />
         <None Include="..\gondwana-logo.png" Pack="true" PackagePath="" Link="gondwana-logo.png" />
     </ItemGroup>
 

--- a/Gondwana.Blazor.Hosting/README.md
+++ b/Gondwana.Blazor.Hosting/README.md
@@ -47,20 +47,16 @@ Then in your Blazor page's `OnAfterRenderAsync`:
 
 ## Documentation
 
--   **Source Code**\
-    https://github.com/isthimius/Gondwana
-
--   **Architecture & Guides**\
-    https://github.com/isthimius/Gondwana/wiki
-
--   **API Reference (Doxygen)**\
-    https://isthimius.github.io/Gondwana/
+-   **[Source Code](https://github.com/isthimius/Gondwana)**
+-   **[Architecture & Guides](https://github.com/isthimius/Gondwana/wiki)**
+-   **[API Reference (Doxygen)](https://isthimius.github.io/Gondwana/)**
+-   **[Release History](https://github.com/Isthimius/Gondwana/blob/master/Gondwana.Blazor.Hosting/CHANGELOG.md)**
 
 ## Related Packages
 
-- `Gondwana` – Core engine
-- `Gondwana.Hosting` – Base hosting framework
-- `Gondwana.Blazor` – Blazor platform adapters
+-   `Gondwana` --- Core engine
+-   `Gondwana.Audio.Browser` --- Browser-based audio playback support
+-   `Gondwana.Blazor` --- Web assembly rendering and input adapters
 
 ## License
 

--- a/Gondwana.Blazor/Gondwana.Blazor.csproj
+++ b/Gondwana.Blazor/Gondwana.Blazor.csproj
@@ -19,6 +19,7 @@
         <PackageTags>game-engine gamedev csharp dotnet blazor wasm webassembly rendering input</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>gondwana-logo.png</PackageIcon>
+		<PackageReleaseNotes>Full changelog: https://github.com/Isthimius/Gondwana/blob/master/CHANGELOG.md</PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>
@@ -31,6 +32,7 @@
 
     <ItemGroup>
         <None Include="README.md" Pack="true" PackagePath="" />
+		<None Include="CHANGELOG.md" Pack="true" PackagePath="" />
         <None Include="..\gondwana-logo.png" Pack="true" PackagePath="" Link="gondwana-logo.png" />
     </ItemGroup>
 

--- a/Gondwana.Blazor/README.md
+++ b/Gondwana.Blazor/README.md
@@ -71,19 +71,16 @@ After initialization, the touch system is accessible via `Engine.Instance.Input.
 
 ## Documentation
 
--   **Source Code**\
-    https://github.com/isthimius/Gondwana
-
--   **Architecture & Guides**\
-    https://github.com/isthimius/Gondwana/wiki
-
--   **API Reference (Doxygen)**\
-    https://isthimius.github.io/Gondwana/
+-   **[Source Code](https://github.com/isthimius/Gondwana)**
+-   **[Architecture & Guides](https://github.com/isthimius/Gondwana/wiki)**
+-   **[API Reference (Doxygen)](https://isthimius.github.io/Gondwana/)**
+-   **[Release History](https://github.com/Isthimius/Gondwana/blob/master/Gondwana.Blazor/CHANGELOG.md)**
 
 ## Related Packages
 
-- `Gondwana` – Core engine
-- `Gondwana.Blazor.Hosting` – Blazor game host
+-   `Gondwana` --- Core engine
+-   `Gondwana.Audio.Browser` --- Browser-based audio playback support
+-   `Gondwana.Blazor.Hosting` --- Blazor-specific game host that integrates rendering and input into the Gondwana lifecycle
 
 ## License
 

--- a/Gondwana.Hosting/Gondwana.Hosting.csproj
+++ b/Gondwana.Hosting/Gondwana.Hosting.csproj
@@ -16,6 +16,7 @@
         <PackageTags>game-engine gamedev csharp dotnet hosting bootstrap lifecycle game-loop initialization engine-host</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageIcon>gondwana-logo.png</PackageIcon>
+		<PackageReleaseNotes>Full changelog: https://github.com/Isthimius/Gondwana/blob/master/CHANGELOG.md</PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>
@@ -24,6 +25,7 @@
 
 	<ItemGroup>
 		<None Include="README.md" Pack="true" PackagePath="" />
+		<None Include="CHANGELOG.md" Pack="true" PackagePath="" />
 		<None Include="..\gondwana-logo.png" Pack="true" PackagePath="" Link="gondwana-logo.png" />
 	</ItemGroup>
 

--- a/Gondwana.Hosting/README.md
+++ b/Gondwana.Hosting/README.md
@@ -34,19 +34,17 @@ public class MyGameHost : GameHostBase
 
 ## Documentation
 
--   **Source Code**\
-    https://github.com/isthimius/Gondwana
-
--   **Architecture & Guides**\
-    https://github.com/isthimius/Gondwana/wiki
-
--   **API Reference (Doxygen)**\
-    https://isthimius.github.io/Gondwana/
+-   **[Source Code](https://github.com/isthimius/Gondwana)**
+-   **[Architecture & Guides](https://github.com/isthimius/Gondwana/wiki)**
+-   **[API Reference (Doxygen)](https://isthimius.github.io/Gondwana/)**
+-   **[Release History](https://github.com/Isthimius/Gondwana/blob/master/Gondwana.Hosting/CHANGELOG.md)**
 
 ## Related Packages
 
-- `Gondwana` — Core engine
-- `Gondwana.WinForms.Hosting` — WinForms-specific host
+-   `Gondwana` --- Core engine
+-   `Gondwana.Avalonia.Hosting` --- Avalonia-specific game host that integrates rendering and input into the Gondwana lifecycle
+-   `Gondwana.Blazor.Hosting` --- Blazor-specific game host that integrates rendering and input into the Gondwana lifecycle
+-   `Gondwana.WinForms.Hosting` --- WinForms-specific game host that integrates rendering and input into the Gondwana lifecycle
 
 ## License
 

--- a/Gondwana.Input.SDL2/Gondwana.Input.SDL2.csproj
+++ b/Gondwana.Input.SDL2/Gondwana.Input.SDL2.csproj
@@ -16,6 +16,7 @@
         <PackageTags>game-engine gamedev csharp dotnet input sdl2 gamepad controller</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageIcon>gondwana-logo.png</PackageIcon>
+		<PackageReleaseNotes>Full changelog: https://github.com/Isthimius/Gondwana/blob/master/CHANGELOG.md</PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>
@@ -28,6 +29,7 @@
 
 	<ItemGroup>
 		<None Include="README.md" Pack="true" PackagePath="" />
+		<None Include="CHANGELOG.md" Pack="true" PackagePath="" />
 		<None Include="..\gondwana-logo.png" Pack="true" PackagePath="" Link="gondwana-logo.png" />
 	</ItemGroup>
 

--- a/Gondwana.Input.SDL2/README.md
+++ b/Gondwana.Input.SDL2/README.md
@@ -30,19 +30,14 @@ host.Engine.InitializeSdlGamepadManager();
 
 ## Documentation
 
--   **Source Code**\
-    https://github.com/isthimius/Gondwana
-
--   **Architecture & Guides**\
-    https://github.com/isthimius/Gondwana/wiki
-
--   **API Reference (Doxygen)**\
-    https://isthimius.github.io/Gondwana/
+-   **[Source Code](https://github.com/isthimius/Gondwana)**
+-   **[Architecture & Guides](https://github.com/isthimius/Gondwana/wiki)**
+-   **[API Reference (Doxygen)](https://isthimius.github.io/Gondwana/)**
+-   **[Release History](https://github.com/Isthimius/Gondwana/blob/master/Gondwana.Input.SDL2/CHANGELOG.md)**
 
 ## Related Packages
 
-- `Gondwana` — Core engine
-- `Gondwana.Hosting` — Engine lifecycle setup
+-   `Gondwana` --- Core engine
 
 ## License
 

--- a/Gondwana.Video/Gondwana.Video.csproj
+++ b/Gondwana.Video/Gondwana.Video.csproj
@@ -17,6 +17,7 @@
         <PackageTags>game-engine gamedev csharp dotnet video playback media rendering</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageIcon>gondwana-logo.png</PackageIcon>
+		<PackageReleaseNotes>Full changelog: https://github.com/Isthimius/Gondwana/blob/master/CHANGELOG.md</PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>
@@ -29,6 +30,7 @@
 
 	<ItemGroup>
 		<None Include="README.md" Pack="true" PackagePath="" />
+		<None Include="CHANGELOG.md" Pack="true" PackagePath="" />
 		<None Include="..\gondwana-logo.png" Pack="true" PackagePath="" Link="gondwana-logo.png" />
 	</ItemGroup>
 

--- a/Gondwana.Video/README.md
+++ b/Gondwana.Video/README.md
@@ -63,19 +63,16 @@ var video = new DirectVideo(
 
 ## Documentation
 
--   **Source Code**\
-    https://github.com/isthimius/Gondwana
-
--   **Architecture & Guides**\
-    https://github.com/isthimius/Gondwana/wiki
-
--   **API Reference (Doxygen)**\
-    https://isthimius.github.io/Gondwana/
+-   **[Source Code](https://github.com/isthimius/Gondwana)**
+-   **[Architecture & Guides](https://github.com/isthimius/Gondwana/wiki)**
+-   **[API Reference (Doxygen)](https://isthimius.github.io/Gondwana/)**
+-   **[Release History](https://github.com/Isthimius/Gondwana/blob/master/Gondwana.Video/CHANGELOG.md)**
 
 ## Related Packages
 
-- `Gondwana` — Core engine
-- `Gondwana.WinForms` — Rendering surface integration
+-   `Gondwana` --- Core engine
+-   `Gondwana.WinForms` --- WinForms rendering and input adapters
+-   `Gondwana.WinForms.Hosting` --- WinForms-specific game host that integrates rendering and input into the Gondwana lifecycle
 
 ## License
 

--- a/Gondwana.Widgets/Gondwana.Widgets.csproj
+++ b/Gondwana.Widgets/Gondwana.Widgets.csproj
@@ -19,10 +19,12 @@
 		<PackageTags>gondwana widgets ui game-ui gamedev csharp dotnet 2d 2.5d directdrawing hud menus dialogs buttons overlays skia skiasharp</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageIcon>gondwana-logo.png</PackageIcon>
+		<PackageReleaseNotes>Full changelog: https://github.com/Isthimius/Gondwana/blob/master/CHANGELOG.md</PackageReleaseNotes>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<None Include="README.md" Pack="true" PackagePath="" />
+		<None Include="CHANGELOG.md" Pack="true" PackagePath="" />
 		<None Include="..\gondwana-logo.png" Link="gondwana-logo.png">
 			<PackagePath></PackagePath>
 			<Pack>true</Pack>

--- a/Gondwana.Widgets/README.md
+++ b/Gondwana.Widgets/README.md
@@ -62,22 +62,14 @@ instead, such as:
 
 ## Documentation
 
--   **Source Code**\
-    https://github.com/isthimius/Gondwana
-
--   **Architecture & Guides**\
-    https://github.com/isthimius/Gondwana/wiki
-
--   **API Reference (Doxygen)**\
-    https://isthimius.github.io/Gondwana/
+-   **[Source Code](https://github.com/isthimius/Gondwana)**
+-   **[Architecture & Guides](https://github.com/isthimius/Gondwana/wiki)**
+-   **[API Reference (Doxygen)](https://isthimius.github.io/Gondwana/)**
+-   **[Release History](https://github.com/Isthimius/Gondwana/blob/master/Gondwana.Widgets/CHANGELOG.md)**
 
 ## Related Packages
 
-- `Gondwana` – Core engine
-- `Gondwana.WinForms` – WinForms adapter
-- `Gondwana.Avalonia` – Avalonia adapter
-- `Gondwana.Blazor` – Blazor WebAssembly adapter
-- `Gondwana.Hosting` – Shared hosting abstractions
+-   `Gondwana` --- Core engine
 
 ## License
 

--- a/Gondwana.WinForms.Hosting/Gondwana.WinForms.Hosting.csproj
+++ b/Gondwana.WinForms.Hosting/Gondwana.WinForms.Hosting.csproj
@@ -16,6 +16,7 @@
         <PackageTags>game-engine gamedev csharp dotnet winforms windows hosting implementation desktop bootstrap lifecycle game-loop initialization engine-host</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageIcon>gondwana-logo.png</PackageIcon>
+		<PackageReleaseNotes>Full changelog: https://github.com/Isthimius/Gondwana/blob/master/CHANGELOG.md</PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>
@@ -26,6 +27,7 @@
 
 	<ItemGroup>
 		<None Include="README.md" Pack="true" PackagePath="" />
+		<None Include="CHANGELOG.md" Pack="true" PackagePath="" />
 		<None Include="..\gondwana-logo.png" Pack="true" PackagePath="" Link="gondwana-logo.png" />
 	</ItemGroup>
 

--- a/Gondwana.WinForms.Hosting/README.md
+++ b/Gondwana.WinForms.Hosting/README.md
@@ -33,20 +33,16 @@ public class MyGameHost : WinFormsGameHost
 
 ## Documentation
 
--   **Source Code**\
-    https://github.com/isthimius/Gondwana
-
--   **Architecture & Guides**\
-    https://github.com/isthimius/Gondwana/wiki
-
--   **API Reference (Doxygen)**\
-    https://isthimius.github.io/Gondwana/
+-   **[Source Code](https://github.com/isthimius/Gondwana)**
+-   **[Architecture & Guides](https://github.com/isthimius/Gondwana/wiki)**
+-   **[API Reference (Doxygen)](https://isthimius.github.io/Gondwana/)**
+-   **[Release History](https://github.com/Isthimius/Gondwana/blob/master/Gondwana/CHANGELOG.md)**
 
 ## Related Packages
 
-- `Gondwana` — Core engine
-- `Gondwana.Hosting` — Base hosting framework
-- `Gondwana.WinForms` — Platform adapters
+-   `Gondwana` --- Core engine
+-   `Gondwana.Hosting` --- Standard platform-agnostic scaffolding for initializing and running Gondwana games
+-   `Gondwana.WinForms` --- WinForms rendering and input adapters
 
 ## License
 

--- a/Gondwana.WinForms.Hosting/README.md
+++ b/Gondwana.WinForms.Hosting/README.md
@@ -36,7 +36,7 @@ public class MyGameHost : WinFormsGameHost
 -   **[Source Code](https://github.com/isthimius/Gondwana)**
 -   **[Architecture & Guides](https://github.com/isthimius/Gondwana/wiki)**
 -   **[API Reference (Doxygen)](https://isthimius.github.io/Gondwana/)**
--   **[Release History](https://github.com/Isthimius/Gondwana/blob/master/Gondwana/CHANGELOG.md)**
+-   **[Release History](https://github.com/Isthimius/Gondwana/blob/master/Gondwana.WinForms.Hosting/CHANGELOG.md)**
 
 ## Related Packages
 

--- a/Gondwana.WinForms/Gondwana.WinForms.csproj
+++ b/Gondwana.WinForms/Gondwana.WinForms.csproj
@@ -20,11 +20,8 @@
         <PackageTags>game-engine gamedev csharp dotnet winforms windows desktop rendering input audio</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageIcon>gondwana-logo.png</PackageIcon>
+		<PackageReleaseNotes>Full changelog: https://github.com/Isthimius/Gondwana/blob/master/CHANGELOG.md</PackageReleaseNotes>
     </PropertyGroup>
-
-    <ItemGroup>
-      <None Remove="C:\Users\mikel\.nuget\packages\naudio.vorbis\1.5.0\contentFiles\any\netstandard2.0\README.md" />
-    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
@@ -37,6 +34,7 @@
 
 	<ItemGroup>
 		<None Include="README.md" Pack="true" PackagePath="" />
+		<None Include="CHANGELOG.md" Pack="true" PackagePath="" />
 		<None Include="..\gondwana-logo.png" Pack="true" PackagePath="" Link="gondwana-logo.png" />
 	</ItemGroup>
 

--- a/Gondwana.WinForms/README.md
+++ b/Gondwana.WinForms/README.md
@@ -30,19 +30,15 @@ Engine.Instance.InitializeWinFormsMouseAdapter(winFormBitmapRenderSurfaceControl
 
 ## Documentation
 
--   **Source Code**\
-    https://github.com/isthimius/Gondwana
-
--   **Architecture & Guides**\
-    https://github.com/isthimius/Gondwana/wiki
-
--   **API Reference (Doxygen)**\
-    https://isthimius.github.io/Gondwana/
+-   **[Source Code](https://github.com/isthimius/Gondwana)**
+-   **[Architecture & Guides](https://github.com/isthimius/Gondwana/wiki)**
+-   **[API Reference (Doxygen)](https://isthimius.github.io/Gondwana/)**
+-   **[Release History](https://github.com/Isthimius/Gondwana/blob/master/Gondwana.WinForms/CHANGELOG.md)**
 
 ## Related Packages
 
-- `Gondwana` — Core engine
-- `Gondwana.WinForms.Hosting` — WinForms game host
+-   `Gondwana` --- Core engine
+-   `Gondwana.WinForms.Hosting` --- WinForms-specific game host that integrates rendering and input into the Gondwana lifecycle
 
 ## License
 

--- a/Gondwana.sln
+++ b/Gondwana.sln
@@ -16,6 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		CHANGELOG.md = CHANGELOG.md
 		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
 		gondwana-logo.png = gondwana-logo.png
 		README.md = README.md
 		ROADMAP.md = ROADMAP.md

--- a/Gondwana/Gondwana.csproj
+++ b/Gondwana/Gondwana.csproj
@@ -19,6 +19,7 @@
         <PackageTags>game-engine gamedev csharp dotnet 2d 2.5d tilemap tiles sprites skia skiaSharp engine</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageIcon>gondwana-logo.png</PackageIcon>
+		<PackageReleaseNotes>Full changelog: https://github.com/Isthimius/Gondwana/blob/master/CHANGELOG.md</PackageReleaseNotes>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -43,6 +44,7 @@
 
 	<ItemGroup>
 		<None Include="README.md" Pack="true" PackagePath="" />
+		<None Include="CHANGELOG.md" Pack="true" PackagePath="" />
 		<None Include="..\gondwana-logo.png" Pack="true" PackagePath="" Link="gondwana-logo.png" />
 	</ItemGroup>
 

--- a/Gondwana/README.md
+++ b/Gondwana/README.md
@@ -28,23 +28,27 @@ dotnet add package Gondwana
 
 ## Documentation
 
--   **Source Code**\
-    https://github.com/isthimius/Gondwana
-
--   **Architecture & Guides**\
-    https://github.com/isthimius/Gondwana/wiki
-
--   **API Reference (Doxygen)**\
-    https://isthimius.github.io/Gondwana/
+-   **[Source Code](https://github.com/isthimius/Gondwana)**
+-   **[Architecture & Guides](https://github.com/isthimius/Gondwana/wiki)**
+-   **[API Reference (Doxygen)](https://isthimius.github.io/Gondwana/)**
+-   **[Release History](https://github.com/Isthimius/Gondwana/blob/master/Gondwana/CHANGELOG.md)**
 
 ## Related Packages
 
+-   `Gondwana.Audio.Browser` --- Browser-based audio playback support
 -   `Gondwana.Audio.Midi` --- MIDI playback and sequencing support
+-   `Gondwana.Avalonia` --- Avalonia rendering and input adapters
+-   `Gondwana.Avalonia.Hosting` --- Avalonia-specific game host that integrates rendering and input into the Gondwana lifecycle
+-   `Gondwana.Blazor` --- Web assembly rendering and input adapters
+-   `Gondwana.Blazor.Hosting` --- Blazor-specific game host that integrates rendering and input into the Gondwana lifecycle
 -   `Gondwana.Hosting` --- Standard platform-agnostic scaffolding for initializing and running Gondwana games
 -   `Gondwana.Input.SDL2` --- SDL2-based input handling
 -   `Gondwana.Video` --- Video playback support
+-   `Gondwana.Widgets` --- UI widget library for creating in-game menus, HUDs, and overlays
 -   `Gondwana.WinForms` --- WinForms rendering and input adapters
 -   `Gondwana.WinForms.Hosting` --- WinForms-specific game host that integrates rendering and input into the Gondwana lifecycle
+-   `Gondwana.Cli` --- Command-line interface for scaffolding and managing Gondwana projects
+-   `Gondwana.Templates` --- Project templates for quickly starting new Gondwana games
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -9,17 +9,26 @@
 
 <img alt="gondwana-logo" src="https://github.com/user-attachments/assets/cefd03d0-de2b-474e-8f72-e4ab672cede3" align="left" width="40%" />
 
-**Gondwana** is a cross-platform 2.5D game and rendering engine written in C#/.NET 8. It provides fine-grained control over rendering, timing, and scene composition, with built-in support for parallax, z-ordering, pixel overhang, collision detection, and particle effects. Gondwana targets desktop and web platforms using SkiaSharp for graphics, Avalonia for cross-platform UI, Blazor for web, and NAudio for sound.
+**Gondwana** is a cross-platform 2D and 2.5D game and rendering engine written in C#/.NET 8. It provides fine-grained control over rendering, timing, and scene composition, with built-in support for parallax, z-ordering, pixel overhang, collision detection, particle effects, and layered scene rendering.
 
-Rather than hiding the render pipeline behind an editor, Gondwana embraces a code-first, engine-driven design. Developers can own their game loop and rendering flow end-to-end when needed, while still benefiting from sensible defaults that allow simpler games to come together quickly. This approach modernizes classic Win32/GDI-era rendering patterns into a clean, modular architecture with explicit control over draw order, dirty-region updates, and timing, yielding a predictable, debuggable engine that works out of the box but does not get in the way as projects grow.
+Gondwana targets desktop and web platforms through SkiaSharp-based rendering, with dedicated integrations for WinForms, Avalonia, and Blazor, and NAudio-based sound support.
+
+Rather than hiding the render pipeline behind an editor, Gondwana embraces a code-first, engine-driven design. Developers can own the game loop and rendering flow end to end when needed, while still benefiting from sensible defaults that allow simpler games to come together quickly.
+
+This approach brings classic Win32/GDI-era rendering principles into a modern, modular architecture with explicit control over draw order, dirty-region updates, scene composition, and timing. The result is a predictable, debuggable engine that works out of the box without getting in the way as projects grow.
+
+## Get Started
 
 **[Make Your First Game in 1 Hour with Gondwana](https://github.com/Isthimius/Gondwana/wiki/Make-Your-First-Game-in-1-Hour)**
 
-- 📘 **Engine Architecture & Guides** — [GitHub Wiki](https://github.com/Isthimius/Gondwana/wiki)
-- 📚 **API Reference (Doxygen)** — [https://isthimius.github.io/Gondwana/](https://isthimius.github.io/Gondwana/)
-- 📦 **NuGet** - [https://www.nuget.org/packages/Gondwana](https://www.nuget.org/packages/Gondwana)
-- 🏷 **All Releases** - https://github.com/Isthimius/Gondwana/releases
-- ⬇️ **Latest CI Build** - https://github.com/Isthimius/Gondwana/actions/workflows/ci-master.yml
+## Documentation & Resources
+
+- 📘 **[Engine Architecture & Guides](https://github.com/Isthimius/Gondwana/wiki)**
+- 📚 **[API Reference](https://isthimius.github.io/Gondwana/)**
+- 📦 **[NuGet Package](https://www.nuget.org/packages/Gondwana)**
+- 🏷️ **[GitHub Releases](https://github.com/Isthimius/Gondwana/releases)**
+- 📜 **[Release History](https://github.com/Isthimius/Gondwana/blob/master/CHANGELOG.md)**
+- ⬇️ **[Latest CI Build](https://github.com/Isthimius/Gondwana/actions/workflows/ci-master.yml)**
 
 ---
 

--- a/Tooling/Gondwana.Cli/Gondwana.Cli.csproj
+++ b/Tooling/Gondwana.Cli/Gondwana.Cli.csproj
@@ -23,6 +23,7 @@
         <PackageTags>game-engine gamedev csharp dotnet cli gondwana tool assets templates doctor scaffold</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>gondwana-logo.png</PackageIcon>
+		<PackageReleaseNotes>Full changelog: https://github.com/Isthimius/Gondwana/blob/master/CHANGELOG.md</PackageReleaseNotes>
         <!-- NU5128: expected for tool packages that have no lib output -->
         <NoWarn>$(NoWarn);NU5128</NoWarn>
     </PropertyGroup>
@@ -38,6 +39,7 @@
 
     <ItemGroup>
         <None Include="README.md" Pack="true" PackagePath="" />
+		<None Include="CHANGELOG.md" Pack="true" PackagePath="" />
         <None Include="..\..\gondwana-logo.png" Pack="true" PackagePath="" Link="gondwana-logo.png" />
     </ItemGroup>
 

--- a/Tooling/Gondwana.Cli/README.md
+++ b/Tooling/Gondwana.Cli/README.md
@@ -505,6 +505,30 @@ Assets:
 
 ---
 
+## Documentation
+
+-   **[Source Code](https://github.com/isthimius/Gondwana)**
+-   **[Architecture & Guides](https://github.com/isthimius/Gondwana/wiki)**
+-   **[API Reference (Doxygen)](https://isthimius.github.io/Gondwana/)**
+-   **[Release History](https://github.com/Isthimius/Gondwana/blob/master/Tooling/Gondwana.Cli/CHANGELOG.md)**
+
+## Related Packages
+
+-   `Gondwana` --- Core engine
+-   `Gondwana.Audio.Browser` --- Browser-based audio playback support
+-   `Gondwana.Audio.Midi` --- MIDI playback and sequencing support
+-   `Gondwana.Avalonia` --- Avalonia rendering and input adapters
+-   `Gondwana.Avalonia.Hosting` --- Avalonia-specific game host that integrates rendering and input into the Gondwana lifecycle
+-   `Gondwana.Blazor` --- Web assembly rendering and input adapters
+-   `Gondwana.Blazor.Hosting` --- Blazor-specific game host that integrates rendering and input into the Gondwana lifecycle
+-   `Gondwana.Hosting` --- Standard platform-agnostic scaffolding for initializing and running Gondwana games
+-   `Gondwana.Input.SDL2` --- SDL2-based input handling
+-   `Gondwana.Video` --- Video playback support
+-   `Gondwana.Widgets` --- UI widget library for creating in-game menus, HUDs, and overlays
+-   `Gondwana.WinForms` --- WinForms rendering and input adapters
+-   `Gondwana.WinForms.Hosting` --- WinForms-specific game host that integrates rendering and input into the Gondwana lifecycle
+-   `Gondwana.Templates` --- Project templates for quickly starting new Gondwana games
+
 ## License
 
-MIT — see [LICENSE](https://github.com/Isthimius/Gondwana/blob/master/LICENSE)
+MIT

--- a/Tooling/Gondwana.Templates/Gondwana.Templates.csproj
+++ b/Tooling/Gondwana.Templates/Gondwana.Templates.csproj
@@ -11,8 +11,6 @@
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <!-- NU5128: expected for template packages that have no lib output -->
         <NoWarn>$(NoWarn);NU5128</NoWarn>
-        <!-- Template packages have no compiled output; suppress empty symbols package (NU5017) -->
-        <IncludeSymbols>false</IncludeSymbols>
 
         <!-- URLs / repository -->
         <PackageProjectUrl>https://github.com/Isthimius/Gondwana/tree/master/Tooling/Gondwana.Templates</PackageProjectUrl>

--- a/Tooling/Gondwana.Templates/Gondwana.Templates.csproj
+++ b/Tooling/Gondwana.Templates/Gondwana.Templates.csproj
@@ -11,6 +11,8 @@
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <!-- NU5128: expected for template packages that have no lib output -->
         <NoWarn>$(NoWarn);NU5128</NoWarn>
+        <!-- Template packages have no compiled output; suppress empty symbols package (NU5017) -->
+        <IncludeSymbols>false</IncludeSymbols>
 
         <!-- URLs / repository -->
         <PackageProjectUrl>https://github.com/Isthimius/Gondwana/tree/master/Tooling/Gondwana.Templates</PackageProjectUrl>

--- a/Tooling/Gondwana.Templates/Gondwana.Templates.csproj
+++ b/Tooling/Gondwana.Templates/Gondwana.Templates.csproj
@@ -26,6 +26,7 @@
         <PackageIcon>gondwana-logo.png</PackageIcon>
 		<RepositoryUrl>https://github.com/Isthimius/Gondwana</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
+		<PackageReleaseNotes>Full changelog: https://github.com/Isthimius/Gondwana/blob/master/CHANGELOG.md</PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>
@@ -46,6 +47,7 @@
 
     <ItemGroup>
         <None Include="README.md" Pack="true" PackagePath="" />
+		<None Include="CHANGELOG.md" Pack="true" PackagePath="" />
         <None Include="..\..\gondwana-logo.png" Pack="true" PackagePath="" Link="gondwana-logo.png" />
     </ItemGroup>
 

--- a/Tooling/Gondwana.Templates/Gondwana.Templates.csproj
+++ b/Tooling/Gondwana.Templates/Gondwana.Templates.csproj
@@ -24,8 +24,6 @@
         <PackageTags>game-engine gamedev csharp dotnet template winforms gondwana scaffold</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>gondwana-logo.png</PackageIcon>
-		<RepositoryUrl>https://github.com/Isthimius/Gondwana</RepositoryUrl>
-		<RepositoryType>git</RepositoryType>
 		<PackageReleaseNotes>Full changelog: https://github.com/Isthimius/Gondwana/blob/master/CHANGELOG.md</PackageReleaseNotes>
     </PropertyGroup>
 

--- a/Tooling/Gondwana.Templates/README.md
+++ b/Tooling/Gondwana.Templates/README.md
@@ -107,9 +107,30 @@ This scaffolds a Blazor WebAssembly project containing:
 
 **Note:** The `gondwana-audio.js` file is automatically included via the `Gondwana.Audio.Browser` NuGet package.
 
-## Further reading
+## Documentation
 
-- **Getting started (1-hour guide)** — [Make Your First Game in 1 Hour](https://github.com/Isthimius/Gondwana/wiki/Make-Your-First-Game-in-1-Hour)
-- **Wiki** — https://github.com/Isthimius/Gondwana/wiki
-- **API reference** — https://isthimius.github.io/Gondwana/
-- **NuGet packages** — https://www.nuget.org/packages/Gondwana
+-   **[Source Code](https://github.com/isthimius/Gondwana)**
+-   **[Architecture & Guides](https://github.com/isthimius/Gondwana/wiki)**
+-   **[API Reference (Doxygen)](https://isthimius.github.io/Gondwana/)**
+-   **[Release History](https://github.com/Isthimius/Gondwana/blob/master/Tooling/Gondwana.Templates/CHANGELOG.md)**
+
+## Related Packages
+
+-   `Gondwana` --- Core engine
+-   `Gondwana.Audio.Browser` --- Browser-based audio playback support
+-   `Gondwana.Audio.Midi` --- MIDI playback and sequencing support
+-   `Gondwana.Avalonia` --- Avalonia rendering and input adapters
+-   `Gondwana.Avalonia.Hosting` --- Avalonia-specific game host that integrates rendering and input into the Gondwana lifecycle
+-   `Gondwana.Blazor` --- Web assembly rendering and input adapters
+-   `Gondwana.Blazor.Hosting` --- Blazor-specific game host that integrates rendering and input into the Gondwana lifecycle
+-   `Gondwana.Hosting` --- Standard platform-agnostic scaffolding for initializing and running Gondwana games
+-   `Gondwana.Input.SDL2` --- SDL2-based input handling
+-   `Gondwana.Video` --- Video playback support
+-   `Gondwana.Widgets` --- UI widget library for creating in-game menus, HUDs, and overlays
+-   `Gondwana.WinForms` --- WinForms rendering and input adapters
+-   `Gondwana.WinForms.Hosting` --- WinForms-specific game host that integrates rendering and input into the Gondwana lifecycle
+-   `Gondwana.Cli` --- Command-line interface for scaffolding and managing Gondwana projects
+
+## License
+
+MIT


### PR DESCRIPTION
- Standardized README and project configurations across all packable projects for consistency.
- Updated solution README with a new link to the CHANGELOG for better documentation access.
- Improved clarity and organization of various component READMEs to enhance user experience.