### PR TITLE
refactor(input): tighten touch and mouse polling behavior

### DIFF
--- a/Gondwana.Avalonia/EngineExtensions.cs
+++ b/Gondwana.Avalonia/EngineExtensions.cs
@@ -63,8 +63,8 @@ public static class EngineExtensions
     /// <remarks>
     /// <para>
     /// On touch-capable devices (Android, iOS), each finger contact is tracked by Avalonia's pointer ID.
-    /// On desktop platforms without a physical touch screen, mouse pointer events are emulated as a single
-    /// touch contact with <c>Id = 0</c>, so desktop mouse behaviour is not affected.
+    /// Mouse pointers are ignored by default, keeping mouse clicks distinct from physical touch contacts.
+    /// Set <paramref name="emulateMouse"/> to <c>true</c> only when a mouse should also produce touch ID 0.
     /// </para>
     /// <para>
     /// After calling this method, access the touch system via <c>engine.Input.TouchEventPoller</c> and attach
@@ -76,8 +76,12 @@ public static class EngineExtensions
     /// <param name="control">
     /// The Avalonia control (or window surface) to capture pointer/touch input from.
     /// </param>
+    /// <param name="emulateMouse">Whether primary mouse input should also emulate touch input.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="control"/> is <see langword="null"/>.</exception>
-    public static void InitializeAvaloniaTouchAdapter(this Engine engine, Control control)
+    public static void InitializeAvaloniaTouchAdapter(
+        this Engine engine,
+        Control control,
+        bool emulateMouse = false)
     {
         Engine.Logger.LogInformation("Initializing AvaloniaTouchInputAdapter...");
 
@@ -87,6 +91,6 @@ public static class EngineExtensions
             throw new ArgumentNullException(nameof(control));
         }
 
-        engine.Input.TouchAdapter = new AvaloniaTouchInputAdapter(control);
+        engine.Input.TouchAdapter = new AvaloniaTouchInputAdapter(control, emulateMouse);
     }
 }

--- a/Gondwana.Avalonia/Input/Mouse/AvaloniaMouseAdapter.cs
+++ b/Gondwana.Avalonia/Input/Mouse/AvaloniaMouseAdapter.cs
@@ -11,8 +11,9 @@ namespace Gondwana.Avalonia.Input.Mouse;
 /// Provides a mouse/pointer input adapter for Avalonia applications, tracking pointer position,
 /// button states, modifier keys, and scroll events.
 /// </summary>
-public sealed class AvaloniaMouseAdapter : IMouseAdapter
+public sealed class AvaloniaMouseAdapter : IMouseAdapter, IDisposable
 {
+    private readonly Control _control;
     private readonly HashSet<GondwanaMouseButton> _pressed = new();
     private Point _currentPosition;
     private KeyboardModifierState _modifiers;
@@ -45,13 +46,12 @@ public sealed class AvaloniaMouseAdapter : IMouseAdapter
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="control"/> is <see langword="null"/>.</exception>
     public AvaloniaMouseAdapter(Control control)
     {
-        if (control == null)
-            throw new ArgumentNullException(nameof(control));
+        _control = control ?? throw new ArgumentNullException(nameof(control));
 
-        control.PointerPressed += OnPointerPressed;
-        control.PointerReleased += OnPointerReleased;
-        control.PointerMoved += OnPointerMoved;
-        control.PointerWheelChanged += OnPointerWheelChanged;
+        _control.PointerPressed += OnPointerPressed;
+        _control.PointerReleased += OnPointerReleased;
+        _control.PointerMoved += OnPointerMoved;
+        _control.PointerWheelChanged += OnPointerWheelChanged;
     }
 
     private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
@@ -106,5 +106,14 @@ public sealed class AvaloniaMouseAdapter : IMouseAdapter
         // Multiply by 120 to approximate Windows WHEEL_DELTA units for compatibility.
         var delta = (int)(e.Delta.Y * 120);
         Interlocked.Add(ref _scrollDelta, delta);
+    }
+
+    /// <summary>Unsubscribes from the control's pointer events.</summary>
+    public void Dispose()
+    {
+        _control.PointerPressed -= OnPointerPressed;
+        _control.PointerReleased -= OnPointerReleased;
+        _control.PointerMoved -= OnPointerMoved;
+        _control.PointerWheelChanged -= OnPointerWheelChanged;
     }
 }

--- a/Gondwana.Avalonia/Input/Touch/AvaloniaTouchInputAdapter.cs
+++ b/Gondwana.Avalonia/Input/Touch/AvaloniaTouchInputAdapter.cs
@@ -17,8 +17,9 @@ namespace Gondwana.Avalonia.Input.Touch;
 /// <remarks>
 /// <para>
 /// On physical touch devices (Android, iOS), each finger contact is tracked by Avalonia's pointer ID and
-/// exposed as a unique <see cref="TouchPoint"/>. On desktop platforms where no hardware touch screen is
-/// present, mouse pointer events are emulated as a single touch point with <c>Id = 0</c>.
+/// exposed as a unique <see cref="TouchPoint"/>. Mouse pointers are ignored by default so an application
+/// that also initializes <c>AvaloniaMouseAdapter</c> does not receive duplicate mouse and touch input.
+/// Pass <c>emulateMouse: true</c> to the constructor when single-contact mouse emulation is desired.
 /// </para>
 /// <para>
 /// Dispose this adapter to unsubscribe from all Avalonia pointer events.
@@ -27,8 +28,10 @@ namespace Gondwana.Avalonia.Input.Touch;
 public sealed class AvaloniaTouchInputAdapter : ITouchAdapter, IDisposable
 {
     private readonly Control _control;
+    private readonly bool _emulateMouse;
     private readonly Dictionary<int, TouchPoint> _activeTouches = new();
     private TouchPoint[] _activeTouchesSnapshot = Array.Empty<TouchPoint>();
+    private readonly ConcurrentQueue<TouchPoint> _pendingBegins = new();
     private readonly ConcurrentQueue<TouchPoint> _pendingEnds = new();
     private bool _isDisposed;
 
@@ -43,12 +46,17 @@ public sealed class AvaloniaTouchInputAdapter : ITouchAdapter, IDisposable
     /// The Avalonia <see cref="Control"/> whose pointer events will be translated into touch events.
     /// Must not be <see langword="null"/>.
     /// </param>
+    /// <param name="emulateMouse">
+    /// When <c>true</c>, primary mouse-button input is also exposed as touch ID 0.
+    /// The default is <c>false</c> to keep mouse and physical touch distinct.
+    /// </param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="control"/> is <see langword="null"/>.
     /// </exception>
-    public AvaloniaTouchInputAdapter(Control control)
+    public AvaloniaTouchInputAdapter(Control control, bool emulateMouse = false)
     {
         _control = control ?? throw new ArgumentNullException(nameof(control));
+        _emulateMouse = emulateMouse;
 
         _control.PointerPressed += OnPointerPressed;
         _control.PointerMoved += OnPointerMoved;
@@ -60,6 +68,9 @@ public sealed class AvaloniaTouchInputAdapter : ITouchAdapter, IDisposable
 
     private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
     {
+        if (e.Pointer.Type == PointerType.Mouse && !_emulateMouse)
+            return;
+
         // For mouse pointers, only emulate touch for the primary (left) button.
         // Right- and middle-clicks should not generate touch events.
         if (e.Pointer.Type == PointerType.Mouse &&
@@ -72,10 +83,14 @@ public sealed class AvaloniaTouchInputAdapter : ITouchAdapter, IDisposable
 
         _activeTouches[id] = point;
         RebuildSnapshot();
+        _pendingBegins.Enqueue(point);
     }
 
     private void OnPointerMoved(object? sender, PointerEventArgs e)
     {
+        if (e.Pointer.Type == PointerType.Mouse && !_emulateMouse)
+            return;
+
         var id = GetTouchId(e.Pointer);
 
         // Only track movement for contacts that are already active (i.e., button/finger is held).
@@ -92,6 +107,9 @@ public sealed class AvaloniaTouchInputAdapter : ITouchAdapter, IDisposable
 
     private void OnPointerReleased(object? sender, PointerReleasedEventArgs e)
     {
+        if (e.Pointer.Type == PointerType.Mouse && !_emulateMouse)
+            return;
+
         var id = GetTouchId(e.Pointer);
 
         if (!_activeTouches.ContainsKey(id))
@@ -107,6 +125,9 @@ public sealed class AvaloniaTouchInputAdapter : ITouchAdapter, IDisposable
 
     private void OnPointerCaptureLost(object? sender, PointerCaptureLostEventArgs e)
     {
+        if (e.Pointer.Type == PointerType.Mouse && !_emulateMouse)
+            return;
+
         // The system cancelled the pointer (e.g. incoming call on Android).
         var id = GetTouchId(e.Pointer);
 
@@ -117,6 +138,18 @@ public sealed class AvaloniaTouchInputAdapter : ITouchAdapter, IDisposable
         _activeTouches.Remove(id);
         RebuildSnapshot();
         _pendingEnds.Enqueue(point);
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<TouchPoint> ConsumeBeganTouches()
+    {
+        if (_pendingBegins.IsEmpty)
+            return Array.Empty<TouchPoint>();
+
+        var snapshot = new List<TouchPoint>(_pendingBegins.Count);
+        while (_pendingBegins.TryDequeue(out var point))
+            snapshot.Add(point);
+        return snapshot;
     }
 
     /// <inheritdoc />

--- a/Gondwana.Blazor/Input/Mouse/BlazorMouseAdapter.cs
+++ b/Gondwana.Blazor/Input/Mouse/BlazorMouseAdapter.cs
@@ -12,8 +12,9 @@ namespace Gondwana.Blazor.Input.Mouse;
 /// Provides a mouse/pointer input adapter for Blazor applications, tracking pointer position,
 /// button states, modifier keys, and scroll wheel input.
 /// </summary>
-public sealed class BlazorMouseAdapter : IMouseAdapter
+public sealed class BlazorMouseAdapter : IMouseAdapter, IDisposable
 {
+    private readonly BlazorBitmapRenderSurfaceComponent _component;
     private readonly HashSet<GondwanaMouseButton> _pressed = new();
     private readonly object _pressedLock = new();
     private Point _currentPosition;
@@ -47,11 +48,12 @@ public sealed class BlazorMouseAdapter : IMouseAdapter
     public BlazorMouseAdapter(BlazorBitmapRenderSurfaceComponent component)
     {
         ArgumentNullException.ThrowIfNull(component);
+        _component = component;
 
-        component.MouseDown += OnMouseDown;
-        component.MouseUp += OnMouseUp;
-        component.MouseMove += OnMouseMove;
-        component.Wheel += OnWheel;
+        _component.MouseDown += OnMouseDown;
+        _component.MouseUp += OnMouseUp;
+        _component.MouseMove += OnMouseMove;
+        _component.Wheel += OnWheel;
     }
 
     private void OnMouseDown(BrowserMouseEventArgs e)
@@ -94,4 +96,13 @@ public sealed class BlazorMouseAdapter : IMouseAdapter
         2 => GondwanaMouseButton.Right,
         _ => GondwanaMouseButton.None
     };
+
+    /// <summary>Unsubscribes from the render component's mouse events.</summary>
+    public void Dispose()
+    {
+        _component.MouseDown -= OnMouseDown;
+        _component.MouseUp -= OnMouseUp;
+        _component.MouseMove -= OnMouseMove;
+        _component.Wheel -= OnWheel;
+    }
 }

--- a/Gondwana.Blazor/Input/Touch/BlazorTouchAdapter.cs
+++ b/Gondwana.Blazor/Input/Touch/BlazorTouchAdapter.cs
@@ -30,6 +30,7 @@ public sealed class BlazorTouchAdapter : ITouchAdapter, IDisposable
     private readonly BlazorBitmapRenderSurfaceComponent _component;
     private readonly Dictionary<long, GondwanaTouchPoint> _activeTouches = new();
     private GondwanaTouchPoint[] _activeTouchesSnapshot = Array.Empty<GondwanaTouchPoint>();
+    private readonly ConcurrentQueue<GondwanaTouchPoint> _pendingBegins = new();
     private readonly ConcurrentQueue<GondwanaTouchPoint> _pendingEnds = new();
     private bool _isDisposed;
 
@@ -61,6 +62,7 @@ public sealed class BlazorTouchAdapter : ITouchAdapter, IDisposable
         {
             var point = new GondwanaTouchPoint((int)t.Identifier, GetPosition(t), TouchPhase.Began);
             _activeTouches[t.Identifier] = point;
+            _pendingBegins.Enqueue(point);
         }
         RebuildSnapshot();
     }
@@ -101,6 +103,18 @@ public sealed class BlazorTouchAdapter : ITouchAdapter, IDisposable
             _pendingEnds.Enqueue(point);
         }
         RebuildSnapshot();
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<GondwanaTouchPoint> ConsumeBeganTouches()
+    {
+        if (_pendingBegins.IsEmpty)
+            return Array.Empty<GondwanaTouchPoint>();
+
+        var snapshot = new List<GondwanaTouchPoint>(_pendingBegins.Count);
+        while (_pendingBegins.TryDequeue(out var point))
+            snapshot.Add(point);
+        return snapshot;
     }
 
     /// <inheritdoc/>

--- a/Gondwana.Widgets/ContainerWidget.cs
+++ b/Gondwana.Widgets/ContainerWidget.cs
@@ -1,7 +1,7 @@
-using Gondwana.Drawing.Direct;
-using Gondwana.Rendering;
 using System.Drawing;
 using System.Numerics;
+using Gondwana.Drawing.Direct;
+using Gondwana.Rendering;
 
 namespace Gondwana.Widgets;
 
@@ -20,26 +20,18 @@ public abstract class ContainerWidget : WidgetBase
     /// <summary>
     /// Initializes a new instance of the <see cref="ContainerWidget"/> class.
     /// </summary>
-    protected ContainerWidget(
-        RenderSurfaceHostBase renderSurfaceHost,
-        DirectDrawingMode mode,
-        PointF anchor = default,
-        string? nickname = null)
-        : base(
-            renderSurfaceHost,
-            mode,
-            anchor,
-            nickname)
+    protected ContainerWidget(RenderSurfaceHostBase renderSurfaceHost,
+                              DirectDrawingMode mode,
+                              PointF anchor = default,
+                              string? nickname = null)
+        : base(renderSurfaceHost, mode, anchor, nickname)
     {
     }
 
     /// <summary>
     /// Gets a snapshot of the child widgets directly owned by this container.
     /// </summary>
-    public IReadOnlyList<WidgetBase> ChildWidgets =>
-        Children
-            .OfType<WidgetBase>()
-            .ToArray();
+    public IReadOnlyList<WidgetBase> ChildWidgets => Children.OfType<WidgetBase>().ToArray();
 
     /// <summary>
     /// Adds a child widget at a local offset from this container's anchor.
@@ -48,26 +40,19 @@ public abstract class ContainerWidget : WidgetBase
     /// <param name="widget">The widget to add.</param>
     /// <param name="localOffsetPx">The local offset from the container anchor.</param>
     /// <returns>The added widget.</returns>
-    protected TWidget AddChild<TWidget>(
-        TWidget widget,
-        Vector2 localOffsetPx)
-        where TWidget : WidgetBase
+    protected TWidget AddChild<TWidget>(TWidget widget,
+                                        Vector2 localOffsetPx)
+                                        where TWidget : WidgetBase
     {
         ArgumentNullException.ThrowIfNull(widget);
 
         if (Children.Contains(widget))
             return widget;
 
-        Add(
-            widget,
-            keepCurrentOffset: false,
-            explicitLocalOffsetPx: localOffsetPx);
+        Add(widget, keepCurrentOffset: false, explicitLocalOffsetPx: localOffsetPx);
 
-        widget.KeyboardInput +=
-            OnChildKeyboardInput;
-
-        widget.Disposing +=
-            OnChildDisposing;
+        widget.KeyboardInput += OnChildKeyboardInput;
+        widget.Disposing += OnChildDisposing;
 
         if (_isShown)
             widget.Show();
@@ -86,9 +71,7 @@ public abstract class ContainerWidget : WidgetBase
     /// <see langword="true"/> when the widget was a direct child; otherwise,
     /// <see langword="false"/>.
     /// </returns>
-    protected bool RemoveChild(
-        WidgetBase widget,
-        bool dispose = false)
+    protected bool RemoveChild(WidgetBase widget, bool dispose = false)
     {
         ArgumentNullException.ThrowIfNull(widget);
 
@@ -98,11 +81,8 @@ public abstract class ContainerWidget : WidgetBase
         if (_isShown)
             widget.Hide();
 
-        widget.KeyboardInput -=
-            OnChildKeyboardInput;
-
-        widget.Disposing -=
-            OnChildDisposing;
+        widget.KeyboardInput -= OnChildKeyboardInput;
+        widget.Disposing -= OnChildDisposing;
 
         Remove(widget);
 
@@ -159,52 +139,37 @@ public abstract class ContainerWidget : WidgetBase
     {
         foreach (WidgetBase child in GetChildWidgetSnapshot())
         {
-            child.KeyboardInput -=
-                OnChildKeyboardInput;
-
-            child.Disposing -=
-                OnChildDisposing;
+            child.KeyboardInput -= OnChildKeyboardInput;
+            child.Disposing -= OnChildDisposing;
         }
 
         base.Dispose();
     }
 
-    private void OnChildKeyboardInput(
-        WidgetKeyboardEventArgs args)
+    private void OnChildKeyboardInput(WidgetKeyboardEventArgs args)
     {
         if (args.Handled)
             return;
 
-        var parentArgs =
-            new WidgetKeyboardEventArgs(
-                this,
-                args.Key,
-                args.KeyAction,
-                args.Modifiers,
-                args.Tick);
+        var parentArgs = new WidgetKeyboardEventArgs(this,
+                                                     args.Key,
+                                                     args.KeyAction,
+                                                     args.Modifiers,
+                                                     args.Tick);
 
         DispatchKeyboardInput(parentArgs);
 
-        args.Handled =
-            parentArgs.Handled;
+        args.Handled = parentArgs.Handled;
     }
 
-    private void OnChildDisposing(
-        object? sender,
-        IDirectDrawable child)
+    private void OnChildDisposing(object? sender, IDirectDrawable child)
     {
         if (child is not WidgetBase widget)
             return;
 
-        widget.KeyboardInput -=
-            OnChildKeyboardInput;
-
-        widget.Disposing -=
-            OnChildDisposing;
+        widget.KeyboardInput -= OnChildKeyboardInput;
+        widget.Disposing -= OnChildDisposing;
     }
 
-    private WidgetBase[] GetChildWidgetSnapshot() =>
-        Children
-            .OfType<WidgetBase>()
-            .ToArray();
+    private WidgetBase[] GetChildWidgetSnapshot() => Children.OfType<WidgetBase>().ToArray();
 }

--- a/Gondwana.Widgets/Controls/ButtonWidget.cs
+++ b/Gondwana.Widgets/Controls/ButtonWidget.cs
@@ -1,10 +1,10 @@
+using System.Drawing;
+using SkiaSharp;
 using Gondwana.Drawing.Direct;
 using Gondwana.Input.Keyboard;
 using Gondwana.Rendering;
 using Gondwana.Rendering.Views;
 using Gondwana.Scenes;
-using SkiaSharp;
-using System.Drawing;
 
 namespace Gondwana.Widgets.Controls;
 
@@ -22,31 +22,20 @@ public sealed class ButtonWidget : WidgetBase
     /// </summary>
     public event Action? Clicked;
 
+    #region constructors
+
     /// <summary>
     /// Initializes a view-level button.
     /// </summary>
-    public ButtonWidget(
-        RenderSurfaceHostBase renderSurfaceHost,
-        View view,
-        Rectangle bounds,
-        string text,
-        string? nickname = null)
-        : base(
-            renderSurfaceHost,
-            DirectDrawingMode.View,
-            bounds.Location,
-            nickname)
+    public ButtonWidget(RenderSurfaceHostBase renderSurfaceHost,
+                        View view,
+                        Rectangle bounds,
+                        string text,
+                        string? nickname = null)
+        : base(renderSurfaceHost, DirectDrawingMode.View, bounds.Location, nickname)
     {
-        Background = CreateBackground(
-            renderSurfaceHost,
-            view,
-            bounds);
-
-        Label = CreateLabel(
-            renderSurfaceHost,
-            view,
-            bounds,
-            text);
+        Background = CreateBackground(renderSurfaceHost, view, bounds);
+        Label = CreateLabel(renderSurfaceHost, view, bounds, text);
 
         CompleteInitialization();
     }
@@ -54,31 +43,22 @@ public sealed class ButtonWidget : WidgetBase
     /// <summary>
     /// Initializes a scene-layer button.
     /// </summary>
-    public ButtonWidget(
-        RenderSurfaceHostBase renderSurfaceHost,
-        SceneLayer sceneLayer,
-        Rectangle bounds,
-        string text,
-        string? nickname = null)
-        : base(
-            renderSurfaceHost,
-            DirectDrawingMode.SceneLayer,
-            bounds.Location,
-            nickname)
+    public ButtonWidget(RenderSurfaceHostBase renderSurfaceHost,
+                        SceneLayer sceneLayer,
+                        Rectangle bounds,
+                        string text,
+                        string? nickname = null)
+        : base(renderSurfaceHost, DirectDrawingMode.SceneLayer, bounds.Location, nickname)
     {
-        Background = CreateBackground(
-            renderSurfaceHost,
-            sceneLayer,
-            bounds);
-
-        Label = CreateLabel(
-            renderSurfaceHost,
-            sceneLayer,
-            bounds,
-            text);
+        Background = CreateBackground(renderSurfaceHost, sceneLayer, bounds);
+        Label = CreateLabel(renderSurfaceHost, sceneLayer, bounds, text);
 
         CompleteInitialization();
     }
+
+    #endregion constructors
+
+    #region public properties
 
     /// <summary>
     /// Gets the rectangle used as the button background and border.
@@ -89,6 +69,10 @@ public sealed class ButtonWidget : WidgetBase
     /// Gets the text block used as the button label.
     /// </summary>
     public TextBlock Label { get; }
+
+    #endregion public properties
+
+    #region public methods
 
     /// <summary>
     /// Sets the button text.
@@ -102,10 +86,9 @@ public sealed class ButtonWidget : WidgetBase
     /// <summary>
     /// Sets the normal, hover, and pressed background colors.
     /// </summary>
-    public ButtonWidget SetBackgroundColors(
-        Color normal,
-        Color hover,
-        Color pressed)
+    public ButtonWidget SetBackgroundColors(Color normal,
+                                            Color hover,
+                                            Color pressed)
     {
         _normalColor = normal;
         _hoverColor = hover;
@@ -121,9 +104,7 @@ public sealed class ButtonWidget : WidgetBase
     /// </summary>
     public ButtonWidget SetTextColor(Color color)
     {
-        Label.SetColors(
-            color,
-            Color.Transparent);
+        Label.SetColors(color, Color.Transparent);
 
         return this;
     }
@@ -150,25 +131,26 @@ public sealed class ButtonWidget : WidgetBase
         Clicked?.Invoke();
     }
 
+    #endregion public methods
+    
+    #region protected methods
+
     /// <inheritdoc/>
-    protected override void OnPointerEnter(
-        WidgetPointerEventArgs args)
+    protected override void OnPointerEnter(WidgetPointerEventArgs args)
     {
         base.OnPointerEnter(args);
         UpdateBackgroundColor(_hoverColor);
     }
 
     /// <inheritdoc/>
-    protected override void OnPointerLeave(
-        WidgetPointerEventArgs args)
+    protected override void OnPointerLeave(WidgetPointerEventArgs args)
     {
         base.OnPointerLeave(args);
         UpdateBackgroundColor(_normalColor);
     }
 
     /// <inheritdoc/>
-    protected override void OnPointerDown(
-        WidgetPointerEventArgs args)
+    protected override void OnPointerDown(WidgetPointerEventArgs args)
     {
         base.OnPointerDown(args);
 
@@ -177,16 +159,14 @@ public sealed class ButtonWidget : WidgetBase
     }
 
     /// <inheritdoc/>
-    protected override void OnPointerUp(
-        WidgetPointerEventArgs args)
+    protected override void OnPointerUp(WidgetPointerEventArgs args)
     {
         base.OnPointerUp(args);
         UpdateBackgroundColor(_hoverColor);
     }
 
     /// <inheritdoc/>
-    protected override void OnPointerClick(
-        WidgetPointerEventArgs args)
+    protected override void OnPointerClick(WidgetPointerEventArgs args)
     {
         base.OnPointerClick(args);
 
@@ -198,13 +178,11 @@ public sealed class ButtonWidget : WidgetBase
     }
 
     /// <inheritdoc/>
-    protected override void OnKeyboardInput(
-        WidgetKeyboardEventArgs args)
+    protected override void OnKeyboardInput(WidgetKeyboardEventArgs args)
     {
         base.OnKeyboardInput(args);
 
-        if (args.KeyAction !=
-            KeyAction.Pressed)
+        if (args.KeyAction != KeyAction.Pressed)
         {
             return;
         }
@@ -217,6 +195,10 @@ public sealed class ButtonWidget : WidgetBase
         PerformClick();
     }
 
+    #endregion protected methods
+
+    #region private methods
+
     private void UpdateBackgroundColor(Color color)
     {
         Background.SetColor(color);
@@ -224,8 +206,7 @@ public sealed class ButtonWidget : WidgetBase
         // DirectRectangle's current color setter rebuilds its paint but does not
         // enqueue a dirty region by itself. Reapplying the existing position
         // performs the required old/new refresh without moving the button.
-        Background.SetPosition(
-            Background.GetPosition());
+        Background.SetPosition(Background.GetPosition());
     }
 
     private void CompleteInitialization()
@@ -239,96 +220,50 @@ public sealed class ButtonWidget : WidgetBase
         IsKeyboardInputEnabled = true;
     }
 
-    private DirectRectangle CreateBackground(
-        RenderSurfaceHostBase host,
-        View view,
-        Rectangle bounds)
+    private DirectRectangle CreateBackground(RenderSurfaceHostBase host, View view, Rectangle bounds)
     {
-        return new DirectRectangle(
-                _normalColor,
-                host,
-                view,
-                bounds,
-                $"{Nickname}.background")
-            .SetFilled(true)
-            .SetBorderColor(
-                Color.FromArgb(
-                    255,
-                    150,
-                    150,
-                    160))
-            .SetStrokeWidth(1.5f)
-            .SetCornerRadius(5f);
+        return new DirectRectangle(_normalColor,
+                                   host,
+                                   view,
+                                   bounds,
+                                   $"{Nickname}.background").SetFilled(true)
+                                                            .SetBorderColor(Color.FromArgb(255, 150, 150, 160))
+                                                            .SetStrokeWidth(1.5f)
+                                                            .SetCornerRadius(5f);
     }
 
-    private DirectRectangle CreateBackground(
-        RenderSurfaceHostBase host,
-        SceneLayer layer,
-        Rectangle bounds)
+    private DirectRectangle CreateBackground(RenderSurfaceHostBase host, SceneLayer layer, Rectangle bounds)
     {
-        return new DirectRectangle(
-                _normalColor,
-                host,
-                layer,
-                bounds,
-                $"{Nickname}.background")
-            .SetFilled(true)
-            .SetBorderColor(
-                Color.FromArgb(
-                    255,
-                    150,
-                    150,
-                    160))
-            .SetStrokeWidth(1.5f)
-            .SetCornerRadius(5f);
+        return new DirectRectangle(_normalColor,
+                                   host,
+                                   layer,
+                                   bounds,
+                                   $"{Nickname}.background").SetFilled(true)
+                                                            .SetBorderColor(Color.FromArgb(255, 150, 150, 160))
+                                                            .SetStrokeWidth(1.5f)
+                                                            .SetCornerRadius(5f);
     }
 
-    private static TextBlock CreateLabel(
-        RenderSurfaceHostBase host,
-        View view,
-        Rectangle bounds,
-        string text)
+    private static TextBlock CreateLabel(RenderSurfaceHostBase host, View view, Rectangle bounds, string text)
     {
-        return new TextBlock(
-                host,
-                view,
-                bounds)
-            .SetText(text)
-            .SetFont(
-                SKTypeface.Default,
-                16f,
-                minSize: 10f)
-            .SetColors(
-                SKColors.White,
-                SKColors.Transparent)
-            .SetAlignment(
-                SKTextAlign.Center,
-                TextBlock.VerticalAlign.Center)
-            .EnableWrapping(false);
+        return new TextBlock(host, view, bounds).SetText(text)
+                                                .SetFont(SKTypeface.Default, 16f, minSize: 10f)
+                                                .SetColors(SKColors.White, SKColors.Transparent)
+                                                .SetAlignment(SKTextAlign.Center, TextBlock.VerticalAlign.Center)
+                                                .EnableWrapping(false);
     }
 
-    private static TextBlock CreateLabel(
-        RenderSurfaceHostBase host,
-        SceneLayer layer,
-        Rectangle bounds,
-        string text)
+    private static TextBlock CreateLabel(RenderSurfaceHostBase host, SceneLayer layer, Rectangle bounds, string text)
     {
-        return new TextBlock(
-                host,
-                layer,
-                view: null,
-                worldBounds: bounds)
-            .SetText(text)
-            .SetFont(
-                SKTypeface.Default,
-                16f,
-                minSize: 10f)
-            .SetColors(
-                SKColors.White,
-                SKColors.Transparent)
-            .SetAlignment(
-                SKTextAlign.Center,
-                TextBlock.VerticalAlign.Center)
-            .EnableWrapping(false);
+        return new TextBlock(host,
+                             layer,
+                             view: null,
+                             worldBounds: bounds).SetText(text)
+                                                 .SetFont(SKTypeface.Default, 16f, minSize: 10f)
+                                                 .SetColors(SKColors.White, SKColors.Transparent)
+                                                 .SetAlignment(SKTextAlign.Center, TextBlock.VerticalAlign.Center)
+                                                 .EnableWrapping(false);
     }
+
+    #endregion private methods
 }

--- a/Gondwana.Widgets/Dialogs/AboutBox.cs
+++ b/Gondwana.Widgets/Dialogs/AboutBox.cs
@@ -1,10 +1,10 @@
+using System.Drawing;
+using System.Numerics;
+using SkiaSharp;
 using Gondwana.Drawing.Direct;
 using Gondwana.Rendering;
 using Gondwana.Rendering.Views;
 using Gondwana.Widgets.Controls;
-using SkiaSharp;
-using System.Drawing;
-using System.Numerics;
 
 namespace Gondwana.Widgets.Dialogs;
 
@@ -17,6 +17,8 @@ public sealed class AboutBox : DialogBox
     private const int DefaultHeight = 330;
 
     private bool _disposed;
+
+    #region constructors
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AboutBox"/> class.
@@ -32,55 +34,42 @@ public sealed class AboutBox : DialogBox
     /// Optional dialog bounds. When omitted, the dialog is centered in the view.
     /// </param>
     /// <param name="nickname">An optional diagnostic nickname.</param>
-    public AboutBox(
-        RenderSurfaceHostBase renderSurfaceHost,
-        View view,
-        string applicationName,
-        string version,
-        string? description = null,
-        string? copyright = null,
-        SKImage? logo = null,
-        Rectangle? bounds = null,
-        string? nickname = null)
-        : base(
-            renderSurfaceHost,
-            view,
-            ResolveBounds(view, bounds),
-            $"About {applicationName}",
-            showCloseButton: true,
-            nickname: nickname ??
-                      "__gondwana_about__")
+    public AboutBox(RenderSurfaceHostBase renderSurfaceHost,
+                    View view,
+                    string applicationName,
+                    string version,
+                    string? description = null,
+                    string? copyright = null,
+                    SKImage? logo = null,
+                    Rectangle? bounds = null,
+                    string? nickname = null)
+        : base(renderSurfaceHost,
+               view,
+               ResolveBounds(view, bounds),
+               $"About {applicationName}",
+               showCloseButton: true,
+               nickname: nickname ?? "__gondwana_about__")
     {
         ApplicationName = applicationName;
         Version = version;
         Description = description;
         Copyright = copyright;
 
-        Rectangle resolvedBounds =
-            ResolveBounds(view, bounds);
+        Rectangle resolvedBounds = ResolveBounds(view, bounds);
 
-        int contentTop =
-            resolvedBounds.Top + 52;
-
-        int contentLeft =
-            resolvedBounds.Left + 24;
+        int contentTop = resolvedBounds.Top + 52;
+        int contentLeft = resolvedBounds.Left + 24;
 
         int contentRightPadding = 24;
 
         if (logo is not null)
         {
-            Logo = new DirectImage(
-                    logo,
-                    renderSurfaceHost,
-                    view,
-                    new Rectangle(
-                        contentLeft,
-                        contentTop,
-                        112,
-                        112),
-                    $"{Nickname}.logo")
-                .SetScaleMode(
-                    DirectImage.ScaleMode.Fit);
+            var logoScreenBounds = new Rectangle(contentLeft, contentTop, 112, 112);
+            Logo = new DirectImage(logo,
+                                   renderSurfaceHost,
+                                   view,
+                                   logoScreenBounds,
+                                   $"{Nickname}.logo").SetScaleMode(DirectImage.ScaleMode.Fit);
 
             Logo.ZOrder = 10_002;
             Add(Logo);
@@ -88,125 +77,61 @@ public sealed class AboutBox : DialogBox
             contentLeft += 132;
         }
 
-        HeaderText = new TextBlock(
-                renderSurfaceHost,
-                view,
-                new Rectangle(
-                    contentLeft,
-                    contentTop,
-                    resolvedBounds.Right -
-                    contentRightPadding -
-                    contentLeft,
-                    44),
-                $"{Nickname}.header")
-            .SetText(applicationName)
-            .SetFont(
-                SKTypeface.Default,
-                26f,
-                minSize: 16f)
-            .SetColors(
-                SKColors.White,
-                SKColors.Transparent)
-            .SetAlignment(
-                SKTextAlign.Left,
-                TextBlock.VerticalAlign.Center)
-            .EnableWrapping(false);
+        var headerTextScreenBounds = new Rectangle(contentLeft, contentTop, resolvedBounds.Right - contentRightPadding - contentLeft, 44);
+        HeaderText = new TextBlock(renderSurfaceHost,
+                                   view,
+                                   headerTextScreenBounds,
+                                   $"{Nickname}.header").SetText(applicationName)
+                                                        .SetFont(SKTypeface.Default, 26f, minSize: 16f)
+                                                        .SetColors(SKColors.White, SKColors.Transparent)
+                                                        .SetAlignment(SKTextAlign.Left, TextBlock.VerticalAlign.Center)
+                                                        .EnableWrapping(false);
 
         HeaderText.ZOrder = 10_002;
         Add(HeaderText);
 
-        VersionText = new TextBlock(
-                renderSurfaceHost,
-                view,
-                new Rectangle(
-                    contentLeft,
-                    contentTop + 44,
-                    resolvedBounds.Right -
-                    contentRightPadding -
-                    contentLeft,
-                    30),
-                $"{Nickname}.version")
-            .SetText($"Version {version}")
-            .SetFont(
-                SKTypeface.Default,
-                15f,
-                minSize: 11f)
-            .SetColors(
-                new SKColor(
-                    205,
-                    205,
-                    215),
-                SKColors.Transparent)
-            .SetAlignment(
-                SKTextAlign.Left,
-                TextBlock.VerticalAlign.Center)
-            .EnableWrapping(false);
+        var versionTextScreenBounds = new Rectangle(contentLeft, contentTop + 44, resolvedBounds.Right - contentRightPadding - contentLeft, 30);
+        VersionText = new TextBlock(renderSurfaceHost,
+                                    view,
+                                    versionTextScreenBounds,
+                                    $"{Nickname}.version").SetText($"Version {version}")
+                                                          .SetFont(SKTypeface.Default, 15f, minSize: 11f)
+                                                          .SetColors(new SKColor(205, 205, 215), SKColors.Transparent)
+                                                          .SetAlignment(SKTextAlign.Left, TextBlock.VerticalAlign.Center)
+                                                          .EnableWrapping(false);
 
         VersionText.ZOrder = 10_002;
         Add(VersionText);
 
-        string detailText =
-            string.Join(
-                Environment.NewLine + Environment.NewLine,
-                new[]
-                {
-                    description,
-                    copyright
-                }
-                .Where(static value =>
-                    !string.IsNullOrWhiteSpace(value)));
+        var detailsTextScreenBounds = new Rectangle(resolvedBounds.Left + 24, contentTop + 126, resolvedBounds.Width - 48, resolvedBounds.Height - 222);
+        string detailText = string.Join(Environment.NewLine + Environment.NewLine,
+                                        new[] { description, copyright }
+                                    .Where(static value => !string.IsNullOrWhiteSpace(value)));
 
-        DetailsText = new TextBlock(
-                renderSurfaceHost,
-                view,
-                new Rectangle(
-                    resolvedBounds.Left + 24,
-                    contentTop + 126,
-                    resolvedBounds.Width - 48,
-                    resolvedBounds.Height - 222),
-                $"{Nickname}.details")
-            .SetText(detailText)
-            .SetFont(
-                SKTypeface.Default,
-                14f,
-                minSize: 10f)
-            .SetColors(
-                new SKColor(
-                    225,
-                    225,
-                    232),
-                SKColors.Transparent)
-            .SetAlignment(
-                SKTextAlign.Left,
-                TextBlock.VerticalAlign.Top)
-            .EnableWrapping(true);
+        DetailsText = new TextBlock(renderSurfaceHost,
+                                    view,
+                                    detailsTextScreenBounds,
+                                    $"{Nickname}.details").SetText(detailText)
+                                                          .SetFont(SKTypeface.Default, 14f, minSize: 10f)
+                                                          .SetColors(new SKColor(225, 225, 232), SKColors.Transparent)
+                                                          .SetAlignment(SKTextAlign.Left, TextBlock.VerticalAlign.Top)
+                                                          .EnableWrapping(true);
 
         DetailsText.ZOrder = 10_002;
         Add(DetailsText);
 
-        Rectangle okBounds =
-            new(
-                resolvedBounds.Right - 116,
-                resolvedBounds.Bottom - 54,
-                92,
-                34);
+        Rectangle okBounds = new(resolvedBounds.Right - 116, resolvedBounds.Bottom - 54, 92, 34);
+        OkButton = new ButtonWidget(renderSurfaceHost, view, okBounds, "OK", $"{Nickname}.ok");
 
-        OkButton = new ButtonWidget(
-            renderSurfaceHost,
-            view,
-            okBounds,
-            "OK",
-            $"{Nickname}.ok");
-
-        AddChild(
-            OkButton,
-            new Vector2(
-                resolvedBounds.Width - 116,
-                resolvedBounds.Height - 54));
+        AddChild(OkButton, new Vector2(resolvedBounds.Width - 116, resolvedBounds.Height - 54));
 
         OkButton.SetButtonZOrder(10_003);
         OkButton.Clicked += OnOkClicked;
     }
+
+    #endregion constructors
+
+    #region public properties
 
     /// <summary>
     /// Gets the application name.
@@ -253,6 +178,10 @@ public sealed class AboutBox : DialogBox
     /// </summary>
     public ButtonWidget OkButton { get; }
 
+    #endregion public properties
+
+    #region exposed methods
+
     /// <inheritdoc/>
     protected override void OnAcceptRequested()
     {
@@ -271,49 +200,34 @@ public sealed class AboutBox : DialogBox
         base.Dispose();
     }
 
+    #endregion exposed methods
+
+    #region private methods
+
     private void OnOkClicked()
     {
         Close(DialogResult.OK);
     }
 
-    private static Rectangle ResolveBounds(
-        View view,
-        Rectangle? bounds)
+    private static Rectangle ResolveBounds(View view, Rectangle? bounds)
     {
         ArgumentNullException.ThrowIfNull(view);
 
         if (bounds is not null)
             return bounds.Value;
 
-        Rectangle viewport =
-            view.Viewport.TargetRectPx;
+        Rectangle viewport = view.Viewport.TargetRectPx;
 
-        int availableWidth =
-            Math.Max(
-                1,
-                viewport.Width - 40);
+        int availableWidth = Math.Max(1, viewport.Width - 40);
+        int availableHeight = Math.Max(1, viewport.Height - 40);
+        int width = Math.Min(DefaultWidth, availableWidth);
+        int height = Math.Min(DefaultHeight, availableHeight);
 
-        int availableHeight =
-            Math.Max(
-                1,
-                viewport.Height - 40);
-
-        int width =
-            Math.Min(
-                DefaultWidth,
-                availableWidth);
-
-        int height =
-            Math.Min(
-                DefaultHeight,
-                availableHeight);
-
-        return new Rectangle(
-            viewport.Left +
-            (viewport.Width - width) / 2,
-            viewport.Top +
-            (viewport.Height - height) / 2,
-            width,
-            height);
+        return new Rectangle(viewport.Left + (viewport.Width - width) / 2,
+                             viewport.Top + (viewport.Height - height) / 2,
+                             width,
+                             height);
     }
+
+    #endregion private methods
 }

--- a/Gondwana.Widgets/Dialogs/DialogBox.cs
+++ b/Gondwana.Widgets/Dialogs/DialogBox.cs
@@ -1,12 +1,12 @@
+using System.Drawing;
+using System.Numerics;
+using SkiaSharp;
 using Gondwana.Drawing.Direct;
 using Gondwana.Input.Keyboard;
 using Gondwana.Rendering;
 using Gondwana.Rendering.Views;
 using Gondwana.Scenes;
 using Gondwana.Widgets.Controls;
-using SkiaSharp;
-using System.Drawing;
-using System.Numerics;
 
 namespace Gondwana.Widgets.Dialogs;
 
@@ -16,8 +16,12 @@ namespace Gondwana.Widgets.Dialogs;
 /// </summary>
 public abstract class DialogBox : DraggableContainerWidget
 {
-    private const int DefaultTitleBarHeight = 36;
-    private const int DefaultCloseButtonSize = 28;
+    protected const int DefaultTitleBarHeight = 36;
+    protected const int DefaultCloseButtonSize = 28;
+
+    protected readonly static Color DefaultPanelColor = Color.FromArgb(245, 36, 36, 44);
+    protected readonly static Color DefaultPanelBorderColor = Color.FromArgb(255, 140, 140, 155);
+    protected readonly static Color DefaultTitleBarColor = Color.FromArgb(255, 57, 57, 72);
 
     private bool _disposed;
 
@@ -26,41 +30,26 @@ public abstract class DialogBox : DraggableContainerWidget
     /// </summary>
     public event Action<DialogResult>? Closed;
 
+    #region constructors
+
     /// <summary>
     /// Initializes a view-level dialog.
     /// </summary>
-    protected DialogBox(
-        RenderSurfaceHostBase renderSurfaceHost,
-        View view,
-        Rectangle bounds,
-        string title,
-        bool showCloseButton = true,
-        string? nickname = null)
-        : base(
-            renderSurfaceHost,
-            DirectDrawingMode.View,
-            bounds.Location,
-            nickname)
+    protected DialogBox(RenderSurfaceHostBase renderSurfaceHost,
+                        View view,
+                        Rectangle bounds,
+                        string title,
+                        bool showCloseButton = true,
+                        string? nickname = null)
+        : base(renderSurfaceHost, DirectDrawingMode.View, bounds.Location, nickname)
     {
         ValidateBounds(bounds);
 
         DialogSize = bounds.Size;
 
-        Panel = CreatePanel(
-            renderSurfaceHost,
-            view,
-            bounds);
-
-        TitleBar = CreateTitleBar(
-            renderSurfaceHost,
-            view,
-            bounds);
-
-        TitleText = CreateTitleText(
-            renderSurfaceHost,
-            view,
-            bounds,
-            title);
+        Panel = CreatePanel(renderSurfaceHost, view, bounds);
+        TitleBar = CreateTitleBar(renderSurfaceHost, view, bounds);
+        TitleText = CreateTitleText(renderSurfaceHost, view, bounds, title);
 
         Add(Panel);
         Add(TitleBar);
@@ -68,18 +57,10 @@ public abstract class DialogBox : DraggableContainerWidget
 
         if (showCloseButton)
         {
-            CloseButton =
-                CreateCloseButton(
-                    renderSurfaceHost,
-                    view,
-                    bounds);
+            CloseButton = CreateCloseButton(renderSurfaceHost, view, bounds);
+            AddChild(CloseButton, GetCloseButtonOffset(bounds.Size));
 
-            AddChild(
-                CloseButton,
-                GetCloseButtonOffset(bounds.Size));
-
-            CloseButton.Clicked +=
-                OnCloseButtonClicked;
+            CloseButton.Clicked += OnCloseButtonClicked;
         }
 
         CompleteInitialization();
@@ -88,38 +69,21 @@ public abstract class DialogBox : DraggableContainerWidget
     /// <summary>
     /// Initializes a scene-layer dialog.
     /// </summary>
-    protected DialogBox(
-        RenderSurfaceHostBase renderSurfaceHost,
-        SceneLayer sceneLayer,
-        Rectangle bounds,
-        string title,
-        bool showCloseButton = true,
-        string? nickname = null)
-        : base(
-            renderSurfaceHost,
-            DirectDrawingMode.SceneLayer,
-            bounds.Location,
-            nickname)
+    protected DialogBox(RenderSurfaceHostBase renderSurfaceHost,
+                        SceneLayer sceneLayer,
+                        Rectangle bounds,
+                        string title,
+                        bool showCloseButton = true,
+                        string? nickname = null)
+        : base(renderSurfaceHost, DirectDrawingMode.SceneLayer, bounds.Location, nickname)
     {
         ValidateBounds(bounds);
 
         DialogSize = bounds.Size;
 
-        Panel = CreatePanel(
-            renderSurfaceHost,
-            sceneLayer,
-            bounds);
-
-        TitleBar = CreateTitleBar(
-            renderSurfaceHost,
-            sceneLayer,
-            bounds);
-
-        TitleText = CreateTitleText(
-            renderSurfaceHost,
-            sceneLayer,
-            bounds,
-            title);
+        Panel = CreatePanel(renderSurfaceHost, sceneLayer, bounds);
+        TitleBar = CreateTitleBar(renderSurfaceHost, sceneLayer, bounds);
+        TitleText = CreateTitleText(renderSurfaceHost, sceneLayer, bounds, title);
 
         Add(Panel);
         Add(TitleBar);
@@ -127,22 +91,18 @@ public abstract class DialogBox : DraggableContainerWidget
 
         if (showCloseButton)
         {
-            CloseButton =
-                CreateCloseButton(
-                    renderSurfaceHost,
-                    sceneLayer,
-                    bounds);
+            CloseButton = CreateCloseButton(renderSurfaceHost, sceneLayer, bounds);
+            AddChild(CloseButton, GetCloseButtonOffset(bounds.Size));
 
-            AddChild(
-                CloseButton,
-                GetCloseButtonOffset(bounds.Size));
-
-            CloseButton.Clicked +=
-                OnCloseButtonClicked;
+            CloseButton.Clicked += OnCloseButtonClicked;
         }
 
         CompleteInitialization();
     }
+
+    #endregion constructors
+
+    #region public properties
 
     /// <summary>
     /// Gets the dialog panel.
@@ -200,11 +160,14 @@ public abstract class DialogBox : DraggableContainerWidget
     /// </remarks>
     public int CancelKey { get; set; } = 27;
 
+    #endregion public properties
+
+    #region exposed methods and hooks
+
     /// <summary>
     /// Closes the dialog with the specified result.
     /// </summary>
-    public void Close(
-        DialogResult result = DialogResult.Close)
+    public void Close(DialogResult result = DialogResult.Close)
     {
         if (IsClosed)
             return;
@@ -224,8 +187,7 @@ public abstract class DialogBox : DraggableContainerWidget
     /// <summary>
     /// Called after the dialog closes.
     /// </summary>
-    protected virtual void OnClosed(
-        DialogResult result)
+    protected virtual void OnClosed(DialogResult result)
     {
     }
 
@@ -238,33 +200,23 @@ public abstract class DialogBox : DraggableContainerWidget
     }
 
     /// <inheritdoc/>
-    protected override bool CanStartDrag(
-        WidgetPointerEventArgs args)
+    protected override bool CanStartDrag(WidgetPointerEventArgs args)
     {
         if (!base.CanStartDrag(args))
             return false;
 
-        RectangleF titleBarBounds =
-            TitleBar.GetDrawLocationScreen(
-                args.View);
+        RectangleF titleBarBounds = TitleBar.GetDrawLocationScreen(args.View);
 
-        return titleBarBounds.Contains(
-            args.ScreenPositionPx.X,
-            args.ScreenPositionPx.Y);
+        return titleBarBounds.Contains(args.ScreenPositionPx.X, args.ScreenPositionPx.Y);
     }
 
     /// <inheritdoc/>
-    protected override void OnKeyboardInput(
-        WidgetKeyboardEventArgs args)
+    protected override void OnKeyboardInput(WidgetKeyboardEventArgs args)
     {
         base.OnKeyboardInput(args);
 
-        if (args.Handled ||
-            args.KeyAction !=
-                KeyAction.Pressed)
-        {
+        if (args.Handled || args.KeyAction != KeyAction.Pressed)
             return;
-        }
 
         if (args.Key == CancelKey)
         {
@@ -297,12 +249,15 @@ public abstract class DialogBox : DraggableContainerWidget
 
         if (CloseButton is not null)
         {
-            CloseButton.Clicked -=
-                OnCloseButtonClicked;
+            CloseButton.Clicked -= OnCloseButtonClicked;
         }
 
         base.Dispose();
     }
+
+    #endregion exposed methods and hooks
+
+    #region private methods
 
     private void CompleteInitialization()
     {
@@ -316,12 +271,9 @@ public abstract class DialogBox : DraggableContainerWidget
         Close(DialogResult.Cancel);
     }
 
-    private static void ValidateBounds(
-        Rectangle bounds)
+    private static void ValidateBounds(Rectangle bounds)
     {
-        if (bounds.Width <= 0 ||
-            bounds.Height <=
-                DefaultTitleBarHeight)
+        if (bounds.Width <= 0 || bounds.Height <= DefaultTitleBarHeight)
         {
             throw new ArgumentOutOfRangeException(
                 nameof(bounds),
@@ -330,161 +282,96 @@ public abstract class DialogBox : DraggableContainerWidget
         }
     }
 
-    private static Vector2 GetCloseButtonOffset(
-        Size size)
+    private static Vector2 GetCloseButtonOffset(Size size)
     {
-        return new Vector2(
-            size.Width -
-            DefaultCloseButtonSize -
-            4,
-            4);
+        return new Vector2(size.Width - DefaultCloseButtonSize - 4, 4);
     }
 
-    private static DirectRectangle CreatePanel(
-        RenderSurfaceHostBase host,
-        View view,
-        Rectangle bounds)
+    private static DirectRectangle CreatePanel(RenderSurfaceHostBase host,
+                                               View view,
+                                               Rectangle bounds)
     {
-        return ConfigurePanel(
-            new DirectRectangle(
-                Color.FromArgb(
-                    245,
-                    36,
-                    36,
-                    44),
-                host,
-                view,
-                bounds));
+        return ConfigurePanel(new DirectRectangle(DefaultPanelColor,
+                              host,
+                              view,
+                              bounds));
     }
 
-    private static DirectRectangle CreatePanel(
-        RenderSurfaceHostBase host,
-        SceneLayer layer,
-        Rectangle bounds)
+    private static DirectRectangle CreatePanel(RenderSurfaceHostBase host,
+                                               SceneLayer layer,
+                                               Rectangle bounds)
     {
-        return ConfigurePanel(
-            new DirectRectangle(
-                Color.FromArgb(
-                    245,
-                    36,
-                    36,
-                    44),
-                host,
-                layer,
-                bounds));
+        return ConfigurePanel(new DirectRectangle(DefaultPanelColor,
+                              host,
+                              layer,
+                              bounds));
     }
 
-    private static DirectRectangle ConfigurePanel(
-        DirectRectangle panel)
+    private static DirectRectangle ConfigurePanel(DirectRectangle panel)
     {
-        panel
-            .SetFilled(true)
-            .SetBorderColor(
-                Color.FromArgb(
-                    255,
-                    140,
-                    140,
-                    155))
-            .SetStrokeWidth(2f)
-            .SetCornerRadius(8f);
+        panel.SetFilled(true)
+             .SetBorderColor(DefaultPanelBorderColor)
+             .SetStrokeWidth(2f)
+             .SetCornerRadius(8f);
 
         panel.ZOrder = 10_000;
 
         return panel;
     }
 
-    private static DirectRectangle CreateTitleBar(
-        RenderSurfaceHostBase host,
-        View view,
-        Rectangle bounds)
+    private static DirectRectangle CreateTitleBar(RenderSurfaceHostBase host,
+                                                  View view,
+                                                  Rectangle bounds)
     {
-        return ConfigureTitleBar(
-            new DirectRectangle(
-                Color.FromArgb(
-                    255,
-                    57,
-                    57,
-                    72),
-                host,
-                view,
-                GetTitleBarBounds(bounds)));
+        return ConfigureTitleBar(new DirectRectangle(DefaultTitleBarColor,
+                                                     host,
+                                                     view,
+                                                     GetTitleBarBounds(bounds)));
     }
 
-    private static DirectRectangle CreateTitleBar(
-        RenderSurfaceHostBase host,
-        SceneLayer layer,
-        Rectangle bounds)
+    private static DirectRectangle CreateTitleBar(RenderSurfaceHostBase host,
+                                                  SceneLayer layer,
+                                                  Rectangle bounds)
     {
-        return ConfigureTitleBar(
-            new DirectRectangle(
-                Color.FromArgb(
-                    255,
-                    57,
-                    57,
-                    72),
-                host,
-                layer,
-                GetTitleBarBounds(bounds)));
+        return ConfigureTitleBar(new DirectRectangle(DefaultTitleBarColor,
+                                                     host,
+                                                     layer,
+                                                     GetTitleBarBounds(bounds)));
     }
 
-    private static DirectRectangle ConfigureTitleBar(
-        DirectRectangle titleBar)
+    private static DirectRectangle ConfigureTitleBar(DirectRectangle titleBar)
     {
-        titleBar
-            .SetFilled(true)
-            .SetCornerRadius(8f);
+        titleBar.SetFilled(true)
+                .SetCornerRadius(8f);
 
         titleBar.ZOrder = 10_001;
 
         return titleBar;
     }
 
-    private static TextBlock CreateTitleText(
-        RenderSurfaceHostBase host,
-        View view,
-        Rectangle bounds,
-        string title)
+    private static TextBlock CreateTitleText(RenderSurfaceHostBase host,
+                                             View view,
+                                             Rectangle bounds,
+                                             string title)
     {
-        return ConfigureTitleText(
-            new TextBlock(
-                host,
-                view,
-                GetTitleTextBounds(bounds)),
-            title);
+        return ConfigureTitleText(new TextBlock(host, view, GetTitleTextBounds(bounds)), title);
     }
 
-    private static TextBlock CreateTitleText(
-        RenderSurfaceHostBase host,
-        SceneLayer layer,
-        Rectangle bounds,
-        string title)
+    private static TextBlock CreateTitleText(RenderSurfaceHostBase host,
+                                             SceneLayer layer,
+                                             Rectangle bounds,
+                                             string title)
     {
-        return ConfigureTitleText(
-            new TextBlock(
-                host,
-                layer,
-                view: null,
-                worldBounds: GetTitleTextBounds(bounds)),
-            title);
+        return ConfigureTitleText(new TextBlock(host, layer, view: null, worldBounds: GetTitleTextBounds(bounds)), title);
     }
 
-    private static TextBlock ConfigureTitleText(
-        TextBlock titleText,
-        string title)
+    private static TextBlock ConfigureTitleText(TextBlock titleText, string title)
     {
-        titleText
-            .SetText(title)
-            .SetFont(
-                SKTypeface.Default,
-                18f,
-                minSize: 12f)
-            .SetColors(
-                SKColors.White,
-                SKColors.Transparent)
-            .SetAlignment(
-                SKTextAlign.Left,
-                TextBlock.VerticalAlign.Center)
-            .EnableWrapping(false);
+        titleText.SetText(title)
+                 .SetFont(SKTypeface.Default, 18f, minSize: 12f)
+                 .SetColors(SKColors.White, SKColors.Transparent)
+                 .SetAlignment(SKTextAlign.Left, TextBlock.VerticalAlign.Center)
+                 .EnableWrapping(false);
 
         titleText.HorizontalPadding = 12f;
         titleText.ZOrder = 10_002;
@@ -492,89 +379,47 @@ public abstract class DialogBox : DraggableContainerWidget
         return titleText;
     }
 
-    private static ButtonWidget CreateCloseButton(
-        RenderSurfaceHostBase host,
-        View view,
-        Rectangle bounds)
+    private static ButtonWidget CreateCloseButton(RenderSurfaceHostBase host,
+                                                  View view,
+                                                  Rectangle bounds)
     {
-        return ConfigureCloseButton(
-            new ButtonWidget(
-                host,
-                view,
-                GetCloseButtonBounds(bounds),
-                "×"));
+        return ConfigureCloseButton(new ButtonWidget(host, view, GetCloseButtonBounds(bounds), "×"));
     }
 
-    private static ButtonWidget CreateCloseButton(
-        RenderSurfaceHostBase host,
-        SceneLayer layer,
-        Rectangle bounds)
+    private static ButtonWidget CreateCloseButton(RenderSurfaceHostBase host,
+                                                  SceneLayer layer,
+                                                  Rectangle bounds)
     {
-        return ConfigureCloseButton(
-            new ButtonWidget(
-                host,
-                layer,
-                GetCloseButtonBounds(bounds),
-                "×"));
+        return ConfigureCloseButton(new ButtonWidget(host, layer, GetCloseButtonBounds(bounds), "×"));
     }
 
-    private static ButtonWidget ConfigureCloseButton(
-        ButtonWidget closeButton)
+    private static ButtonWidget ConfigureCloseButton(ButtonWidget closeButton)
     {
-        closeButton
-            .SetBackgroundColors(
-                Color.FromArgb(
-                    0,
-                    0,
-                    0,
-                    0),
-                Color.FromArgb(
-                    255,
-                    110,
-                    55,
-                    62),
-                Color.FromArgb(
-                    255,
-                    145,
-                    45,
-                    55))
-            .SetTextColor(Color.White)
-            .SetButtonZOrder(10_003);
+        closeButton.SetBackgroundColors(Color.FromArgb(0, 0, 0, 0),
+                                        Color.FromArgb(255, 110, 55, 62),
+                                        Color.FromArgb(255, 145, 45, 55))
+                   .SetTextColor(Color.White)
+                   .SetButtonZOrder(10_003);
 
         return closeButton;
     }
 
-    private static Rectangle GetTitleBarBounds(
-        Rectangle bounds)
+    private static Rectangle GetTitleBarBounds(Rectangle bounds)
     {
-        return new Rectangle(
-            bounds.X,
-            bounds.Y,
-            bounds.Width,
-            DefaultTitleBarHeight);
+        return new Rectangle(bounds.X, bounds.Y, bounds.Width, DefaultTitleBarHeight);
     }
 
     private static Rectangle GetTitleTextBounds(
         Rectangle bounds)
     {
-        return new Rectangle(
-            bounds.X,
-            bounds.Y,
-            bounds.Width -
-            DefaultCloseButtonSize -
-            12,
-            DefaultTitleBarHeight);
+        return new Rectangle(bounds.X, bounds.Y, bounds.Width - DefaultCloseButtonSize - 12, DefaultTitleBarHeight);
     }
 
     private static Rectangle GetCloseButtonBounds(
         Rectangle bounds)
     {
-        return new Rectangle(
-            bounds.Right -
-            DefaultCloseButtonSize -
-            4,
-            bounds.Y + 4,
-            DefaultCloseButtonSize,
-            DefaultCloseButtonSize);
+        return new Rectangle(bounds.Right - DefaultCloseButtonSize - 4, bounds.Y + 4, DefaultCloseButtonSize, DefaultCloseButtonSize);
     }
+
+    #endregion private methods
 }

--- a/Gondwana.Widgets/DraggableContainerWidget.cs
+++ b/Gondwana.Widgets/DraggableContainerWidget.cs
@@ -1,8 +1,8 @@
+using System.Drawing;
+using System.Numerics;
 using Gondwana.Drawing.Direct;
 using Gondwana.Rendering;
 using Gondwana.Rendering.Views;
-using System.Drawing;
-using System.Numerics;
 
 namespace Gondwana.Widgets;
 
@@ -31,19 +31,13 @@ public abstract class DraggableContainerWidget : ContainerWidget
     /// <summary>
     /// Initializes a new instance of the <see cref="DraggableContainerWidget"/> class.
     /// </summary>
-    protected DraggableContainerWidget(
-        RenderSurfaceHostBase renderSurfaceHost,
-        DirectDrawingMode mode,
-        PointF anchor = default,
-        string? nickname = null)
-        : base(
-            renderSurfaceHost,
-            mode,
-            anchor,
-            nickname)
+    protected DraggableContainerWidget(RenderSurfaceHostBase renderSurfaceHost,
+                                       DirectDrawingMode mode,
+                                       PointF anchor = default,
+                                       string? nickname = null)
+        : base(renderSurfaceHost, mode, anchor, nickname)
     {
-        _dragBehavior =
-            new WidgetDragBehavior(this);
+        _dragBehavior = new WidgetDragBehavior(this);
     }
 
     /// <summary>
@@ -58,8 +52,7 @@ public abstract class DraggableContainerWidget : ContainerWidget
     /// <summary>
     /// Gets whether a drag operation is active.
     /// </summary>
-    public bool IsDragging =>
-        _dragBehavior.IsDragging;
+    public bool IsDragging => _dragBehavior.IsDragging;
 
     /// <summary>
     /// Gets or sets the minimum pointer movement required to begin dragging.
@@ -75,8 +68,7 @@ public abstract class DraggableContainerWidget : ContainerWidget
     {
         base.ProcessHidden();
 
-        _dragBehavior.ResetPointerState(
-            clearClickSuppression: true);
+        _dragBehavior.ResetPointerState(clearClickSuppression: true);
     }
 
     /// <inheritdoc/>
@@ -84,51 +76,42 @@ public abstract class DraggableContainerWidget : ContainerWidget
     {
         base.ProcessCancelled();
 
-        _dragBehavior.ResetPointerState(
-            clearClickSuppression: true);
+        _dragBehavior.ResetPointerState(clearClickSuppression: true);
     }
 
     /// <inheritdoc/>
-    protected sealed override void ProcessPointerDown(
-        WidgetPointerEventArgs args)
+    protected sealed override void ProcessPointerDown(WidgetPointerEventArgs args)
     {
         base.ProcessPointerDown(args);
 
-        _dragBehavior.ProcessPointerDown(
-            args,
-            CanStartDrag);
+        _dragBehavior.ProcessPointerDown(args, CanStartDrag);
     }
 
     /// <inheritdoc/>
-    protected sealed override void ProcessPointerMove(
-        WidgetPointerEventArgs args)
+    protected sealed override void ProcessPointerMove(WidgetPointerEventArgs args)
     {
         base.ProcessPointerMove(args);
 
-        _dragBehavior.ProcessPointerMove(
-            args,
-            ConvertScreenDeltaToPositionDelta,
-            ConstrainDragPosition,
-            DispatchDragStarted,
-            DispatchDragged);
+        _dragBehavior.ProcessPointerMove(args,
+                                         ConvertScreenDeltaToPositionDelta,
+                                         ConstrainDragPosition,
+                                         DispatchDragStarted,
+                                         DispatchDragged);
     }
 
     /// <inheritdoc/>
-    protected sealed override void ProcessPointerUp(
-        WidgetPointerEventArgs args)
+    protected sealed override void ProcessPointerUp(WidgetPointerEventArgs args)
     {
         base.ProcessPointerUp(args);
 
-        _dragBehavior.ProcessPointerUp(
-            args,
-            ConvertScreenDeltaToPositionDelta,
-            ConstrainDragPosition,
-            DispatchDragEnded);
+        _dragBehavior.ProcessPointerUp(args,
+                                       ConvertScreenDeltaToPositionDelta,
+                                       ConstrainDragPosition,
+                                       DispatchDragEnded);
     }
 
     /// <inheritdoc/>
-    protected sealed override bool ShouldDispatchPointerClick(
-        WidgetPointerEventArgs args)
+    protected sealed override bool ShouldDispatchPointerClick(WidgetPointerEventArgs args)
     {
         return base.ShouldDispatchPointerClick(args) &&
                _dragBehavior.ShouldDispatchPointerClick(args);
@@ -137,8 +120,7 @@ public abstract class DraggableContainerWidget : ContainerWidget
     /// <summary>
     /// Determines whether a pointer-down event may begin drag tracking.
     /// </summary>
-    protected virtual bool CanStartDrag(
-        WidgetPointerEventArgs args)
+    protected virtual bool CanStartDrag(WidgetPointerEventArgs args)
     {
         return _dragBehavior.CanStartDrag(args);
     }
@@ -146,21 +128,15 @@ public abstract class DraggableContainerWidget : ContainerWidget
     /// <summary>
     /// Converts total screen movement into this widget's coordinate space.
     /// </summary>
-    protected virtual Vector2 ConvertScreenDeltaToPositionDelta(
-        Vector2 totalScreenDeltaPx,
-        View view)
+    protected virtual Vector2 ConvertScreenDeltaToPositionDelta(Vector2 totalScreenDeltaPx, View view)
     {
-        return _dragBehavior
-            .ConvertScreenDeltaToPositionDelta(
-                totalScreenDeltaPx,
-                view);
+        return _dragBehavior.ConvertScreenDeltaToPositionDelta(totalScreenDeltaPx, view);
     }
 
     /// <summary>
     /// Constrains a proposed anchor position before it is applied.
     /// </summary>
-    protected virtual Vector2 ConstrainDragPosition(
-        Vector2 proposedPositionPx)
+    protected virtual Vector2 ConstrainDragPosition(Vector2 proposedPositionPx)
     {
         return proposedPositionPx;
     }
@@ -168,43 +144,37 @@ public abstract class DraggableContainerWidget : ContainerWidget
     /// <summary>
     /// Called when dragging begins.
     /// </summary>
-    protected virtual void OnDragStarted(
-        WidgetDragEventArgs args)
+    protected virtual void OnDragStarted(WidgetDragEventArgs args)
     {
     }
 
     /// <summary>
     /// Called after the container moves during dragging.
     /// </summary>
-    protected virtual void OnDragged(
-        WidgetDragEventArgs args)
+    protected virtual void OnDragged(WidgetDragEventArgs args)
     {
     }
 
     /// <summary>
     /// Called when dragging ends.
     /// </summary>
-    protected virtual void OnDragEnded(
-        WidgetDragEventArgs args)
+    protected virtual void OnDragEnded(WidgetDragEventArgs args)
     {
     }
 
-    private void DispatchDragStarted(
-        WidgetDragEventArgs args)
+    private void DispatchDragStarted(WidgetDragEventArgs args)
     {
         OnDragStarted(args);
         DragStarted?.Invoke(args);
     }
 
-    private void DispatchDragged(
-        WidgetDragEventArgs args)
+    private void DispatchDragged(WidgetDragEventArgs args)
     {
         OnDragged(args);
         Dragged?.Invoke(args);
     }
 
-    private void DispatchDragEnded(
-        WidgetDragEventArgs args)
+    private void DispatchDragEnded(WidgetDragEventArgs args)
     {
         OnDragEnded(args);
         DragEnded?.Invoke(args);

--- a/Gondwana.Widgets/DraggableWidgetBase.cs
+++ b/Gondwana.Widgets/DraggableWidgetBase.cs
@@ -1,8 +1,8 @@
+using System.Drawing;
+using System.Numerics;
 using Gondwana.Drawing.Direct;
 using Gondwana.Rendering;
 using Gondwana.Rendering.Views;
-using System.Drawing;
-using System.Numerics;
 
 namespace Gondwana.Widgets;
 
@@ -31,19 +31,13 @@ public abstract class DraggableWidgetBase : WidgetBase
     /// <summary>
     /// Initializes a new instance of the <see cref="DraggableWidgetBase"/> class.
     /// </summary>
-    protected DraggableWidgetBase(
-        RenderSurfaceHostBase renderSurfaceHost,
-        DirectDrawingMode mode,
-        PointF anchor = default,
-        string? nickname = null)
-        : base(
-            renderSurfaceHost,
-            mode,
-            anchor,
-            nickname)
+    protected DraggableWidgetBase(RenderSurfaceHostBase renderSurfaceHost,
+                                  DirectDrawingMode mode,
+                                  PointF anchor = default,
+                                  string? nickname = null)
+        : base(renderSurfaceHost, mode, anchor, nickname)
     {
-        _dragBehavior =
-            new WidgetDragBehavior(this);
+        _dragBehavior = new WidgetDragBehavior(this);
     }
 
     /// <summary>
@@ -58,8 +52,7 @@ public abstract class DraggableWidgetBase : WidgetBase
     /// <summary>
     /// Gets whether a drag operation is active.
     /// </summary>
-    public bool IsDragging =>
-        _dragBehavior.IsDragging;
+    public bool IsDragging => _dragBehavior.IsDragging;
 
     /// <summary>
     /// Gets or sets the minimum pointer movement required to begin dragging.
@@ -74,34 +67,25 @@ public abstract class DraggableWidgetBase : WidgetBase
     protected sealed override void ProcessHidden()
     {
         base.ProcessHidden();
-
-        _dragBehavior.ResetPointerState(
-            clearClickSuppression: true);
+        _dragBehavior.ResetPointerState(clearClickSuppression: true);
     }
 
     /// <inheritdoc/>
     protected sealed override void ProcessCancelled()
     {
         base.ProcessCancelled();
-
-        _dragBehavior.ResetPointerState(
-            clearClickSuppression: true);
+        _dragBehavior.ResetPointerState(clearClickSuppression: true);
     }
 
     /// <inheritdoc/>
-    protected sealed override void ProcessPointerDown(
-        WidgetPointerEventArgs args)
+    protected sealed override void ProcessPointerDown(WidgetPointerEventArgs args)
     {
         base.ProcessPointerDown(args);
-
-        _dragBehavior.ProcessPointerDown(
-            args,
-            CanStartDrag);
+        _dragBehavior.ProcessPointerDown(args, CanStartDrag);
     }
 
     /// <inheritdoc/>
-    protected sealed override void ProcessPointerMove(
-        WidgetPointerEventArgs args)
+    protected sealed override void ProcessPointerMove(WidgetPointerEventArgs args)
     {
         base.ProcessPointerMove(args);
 
@@ -114,8 +98,7 @@ public abstract class DraggableWidgetBase : WidgetBase
     }
 
     /// <inheritdoc/>
-    protected sealed override void ProcessPointerUp(
-        WidgetPointerEventArgs args)
+    protected sealed override void ProcessPointerUp(WidgetPointerEventArgs args)
     {
         base.ProcessPointerUp(args);
 
@@ -127,8 +110,7 @@ public abstract class DraggableWidgetBase : WidgetBase
     }
 
     /// <inheritdoc/>
-    protected sealed override bool ShouldDispatchPointerClick(
-        WidgetPointerEventArgs args)
+    protected sealed override bool ShouldDispatchPointerClick(WidgetPointerEventArgs args)
     {
         return base.ShouldDispatchPointerClick(args) &&
                _dragBehavior.ShouldDispatchPointerClick(args);
@@ -137,8 +119,7 @@ public abstract class DraggableWidgetBase : WidgetBase
     /// <summary>
     /// Determines whether a pointer-down event may begin drag tracking.
     /// </summary>
-    protected virtual bool CanStartDrag(
-        WidgetPointerEventArgs args)
+    protected virtual bool CanStartDrag(WidgetPointerEventArgs args)
     {
         return _dragBehavior.CanStartDrag(args);
     }
@@ -146,21 +127,16 @@ public abstract class DraggableWidgetBase : WidgetBase
     /// <summary>
     /// Converts total screen movement into this widget's coordinate space.
     /// </summary>
-    protected virtual Vector2 ConvertScreenDeltaToPositionDelta(
-        Vector2 totalScreenDeltaPx,
-        View view)
+    protected virtual Vector2 ConvertScreenDeltaToPositionDelta(Vector2 totalScreenDeltaPx,
+                                                                View view)
     {
-        return _dragBehavior
-            .ConvertScreenDeltaToPositionDelta(
-                totalScreenDeltaPx,
-                view);
+        return _dragBehavior.ConvertScreenDeltaToPositionDelta(totalScreenDeltaPx, view);
     }
 
     /// <summary>
     /// Constrains a proposed anchor position before it is applied.
     /// </summary>
-    protected virtual Vector2 ConstrainDragPosition(
-        Vector2 proposedPositionPx)
+    protected virtual Vector2 ConstrainDragPosition(Vector2 proposedPositionPx)
     {
         return proposedPositionPx;
     }
@@ -168,43 +144,37 @@ public abstract class DraggableWidgetBase : WidgetBase
     /// <summary>
     /// Called when dragging begins.
     /// </summary>
-    protected virtual void OnDragStarted(
-        WidgetDragEventArgs args)
+    protected virtual void OnDragStarted(WidgetDragEventArgs args)
     {
     }
 
     /// <summary>
     /// Called after the widget moves during dragging.
     /// </summary>
-    protected virtual void OnDragged(
-        WidgetDragEventArgs args)
+    protected virtual void OnDragged(WidgetDragEventArgs args)
     {
     }
 
     /// <summary>
     /// Called when dragging ends.
     /// </summary>
-    protected virtual void OnDragEnded(
-        WidgetDragEventArgs args)
+    protected virtual void OnDragEnded(WidgetDragEventArgs args)
     {
     }
 
-    private void DispatchDragStarted(
-        WidgetDragEventArgs args)
+    private void DispatchDragStarted(WidgetDragEventArgs args)
     {
         OnDragStarted(args);
         DragStarted?.Invoke(args);
     }
 
-    private void DispatchDragged(
-        WidgetDragEventArgs args)
+    private void DispatchDragged(WidgetDragEventArgs args)
     {
         OnDragged(args);
         Dragged?.Invoke(args);
     }
 
-    private void DispatchDragEnded(
-        WidgetDragEventArgs args)
+    private void DispatchDragEnded(WidgetDragEventArgs args)
     {
         OnDragEnded(args);
         DragEnded?.Invoke(args);

--- a/Gondwana.Widgets/Overlays/SplashScreen.cs
+++ b/Gondwana.Widgets/Overlays/SplashScreen.cs
@@ -1,11 +1,12 @@
 using System.Drawing;
+using Microsoft.Extensions.Logging;
+using SkiaSharp;
 using Gondwana.Drawing.Direct;
 using Gondwana.Logging;
 using Gondwana.Rendering;
 using Gondwana.Rendering.Views;
 using Gondwana.Timers;
-using Microsoft.Extensions.Logging;
-using SkiaSharp;
+
 using Timer = Gondwana.Timers.Timer;
 
 namespace Gondwana.Widgets.Overlays;
@@ -370,7 +371,7 @@ public sealed class SplashScreen : WidgetBase
         return completionSource.Task;
     }
 
-    private async Task ExecuteHoldDelegatesAsync(
+    private static async Task ExecuteHoldDelegatesAsync(
         Action? onHoldingSync,
         Func<Task>? onHoldingAsync)
     {

--- a/Gondwana.Widgets/WidgetBase.cs
+++ b/Gondwana.Widgets/WidgetBase.cs
@@ -1,7 +1,7 @@
-﻿using Gondwana.Drawing.Direct;
+﻿using System.Drawing;
+using Gondwana.Drawing.Direct;
 using Gondwana.Rendering;
 using Gondwana.Rendering.Views;
-using System.Drawing;
 
 namespace Gondwana.Widgets;
 
@@ -87,11 +87,10 @@ public abstract class WidgetBase : DirectComposite
     /// <param name="mode">The drawing mode used to render the widget.</param>
     /// <param name="anchor">The anchor position used by the widget.</param>
     /// <param name="nickname">The optional nickname assigned to the widget.</param>
-    protected WidgetBase(
-        RenderSurfaceHostBase renderSurfaceHost,
-        DirectDrawingMode mode,
-        PointF anchor = default,
-        string? nickname = null)
+    protected WidgetBase(RenderSurfaceHostBase renderSurfaceHost,
+                         DirectDrawingMode mode,
+                         PointF anchor = default,
+                         string? nickname = null)
         : base(renderSurfaceHost, mode, anchor, nickname)
     {
     }
@@ -196,9 +195,8 @@ public abstract class WidgetBase : DirectComposite
     /// <returns>
     /// <c>true</c> if the widget contains the specified screen position; otherwise, <c>false</c>.
     /// </returns>
-    public virtual bool HitTest(
-        View view,
-        Point screenPositionPx)
+    public virtual bool HitTest(View view,
+                                Point screenPositionPx)
     {
         ArgumentNullException.ThrowIfNull(view);
 
@@ -209,18 +207,16 @@ public abstract class WidgetBase : DirectComposite
             return false;
         }
 
-        if (Mode == DirectDrawingMode.View &&
-            !ReferenceEquals(View, view))
+        if (Mode == DirectDrawingMode.View
+                 && !ReferenceEquals(View, view))
         {
             return false;
         }
 
         RectangleF screenBounds = GetDrawLocationScreen(view);
 
-        return !screenBounds.IsEmpty &&
-               screenBounds.Contains(
-                   screenPositionPx.X,
-                   screenPositionPx.Y);
+        return !screenBounds.IsEmpty
+            && screenBounds.Contains(screenPositionPx.X, screenPositionPx.Y);
     }
 
     /// <summary>
@@ -230,26 +226,20 @@ public abstract class WidgetBase : DirectComposite
     /// <returns>
     /// <c>true</c> if the widget contains the specified screen position; otherwise, <c>false</c>.
     /// </returns>
-    public virtual bool HitTest(
-        Point screenPositionPx)
+    public virtual bool HitTest(Point screenPositionPx)
     {
         var views = RenderSurfaceHost.ViewManager.Views;
 
-        for (int index = views.Count - 1;
-             index >= 0;
-             index--)
+        for (int index = views.Count - 1; index >= 0; index--)
         {
             View view = views[index];
 
-            if (!view.Viewport.TargetRectPx.Contains(
-                screenPositionPx))
+            if (!view.Viewport.TargetRectPx.Contains(screenPositionPx))
             {
                 continue;
             }
 
-            return HitTest(
-                view,
-                screenPositionPx);
+            return HitTest(view, screenPositionPx);
         }
 
         return false;

--- a/Gondwana.Widgets/WidgetDragBehavior.cs
+++ b/Gondwana.Widgets/WidgetDragBehavior.cs
@@ -1,7 +1,7 @@
+using System.Numerics;
+using System.Drawing;
 using Gondwana.Drawing.Direct;
 using Gondwana.Rendering.Views;
-using System.Drawing;
-using System.Numerics;
 
 namespace Gondwana.Widgets;
 
@@ -24,9 +24,7 @@ internal sealed class WidgetDragBehavior
 
     internal WidgetDragBehavior(WidgetBase owner)
     {
-        _owner =
-            owner ??
-            throw new ArgumentNullException(nameof(owner));
+        _owner = owner ?? throw new ArgumentNullException(nameof(owner));
     }
 
     internal bool IsDragEnabled { get; set; } = true;
@@ -57,12 +55,10 @@ internal sealed class WidgetDragBehavior
                args.IsPrimaryButton;
     }
 
-    internal void ProcessPointerDown(
-        WidgetPointerEventArgs args,
-        Func<WidgetPointerEventArgs, bool> canStartDrag)
+    internal void ProcessPointerDown(WidgetPointerEventArgs args,
+                                     Func<WidgetPointerEventArgs, bool> canStartDrag)
     {
-        if (_isPointerDown ||
-            !canStartDrag(args))
+        if (_isPointerDown || !canStartDrag(args))
         {
             return;
         }
@@ -71,116 +67,76 @@ internal sealed class WidgetDragBehavior
         _suppressNextPointerClick = false;
         IsDragging = false;
 
-        _dragStartScreenPositionPx =
-            args.ScreenPositionPx;
-
-        _dragStartWidgetPositionPx =
-            _owner.GetPosition();
-
+        _dragStartScreenPositionPx = args.ScreenPositionPx;
+        _dragStartWidgetPositionPx = _owner.GetPosition();
         _dragButton = args.Button;
         _dragPointerId = args.PointerId;
         _dragView = args.View;
-
-        _dragStartPointerPositionPx =
-            GetPointerPositionInWidgetSpace(
-                args.ScreenPositionPx,
-                args.View);
+        _dragStartPointerPositionPx = GetPointerPositionInWidgetSpace(args.ScreenPositionPx, args.View);
     }
 
-    internal void ProcessPointerMove(
-        WidgetPointerEventArgs args,
-        Func<Vector2, View, Vector2> convertDelta,
-        Func<Vector2, Vector2> constrainPosition,
-        Action<WidgetDragEventArgs> dragStarted,
-        Action<WidgetDragEventArgs> dragged)
+    internal void ProcessPointerMove(WidgetPointerEventArgs args,
+                                     Func<Vector2, View, Vector2> convertDelta,
+                                     Func<Vector2, Vector2> constrainPosition,
+                                     Action<WidgetDragEventArgs> dragStarted,
+                                     Action<WidgetDragEventArgs> dragged)
     {
-        if (!_isPointerDown ||
-            args.PointerId != _dragPointerId)
-        {
+        if (!_isPointerDown || args.PointerId != _dragPointerId)
             return;
-        }
 
-        Vector2 totalScreenDeltaPx =
-            GetTotalScreenDelta(
-                args.ScreenPositionPx);
+        Vector2 totalScreenDeltaPx = GetTotalScreenDelta(args.ScreenPositionPx);
 
         if (!IsDragging)
         {
-            float thresholdSquared =
-                DragThresholdPx *
-                DragThresholdPx;
-
-            if (totalScreenDeltaPx.LengthSquared() <
-                thresholdSquared)
-            {
+            float thresholdSquared = DragThresholdPx * DragThresholdPx;
+            if (totalScreenDeltaPx.LengthSquared() < thresholdSquared)
                 return;
-            }
-
+            
             IsDragging = true;
             _suppressNextPointerClick = true;
 
-            dragStarted(
-                CreateDragEventArgs(args));
+            dragStarted(CreateDragEventArgs(args));
 
             // The callback may cancel or hide the widget, which resets this state.
             if (!IsDragging)
                 return;
         }
 
-        ApplyDragPosition(
-            totalScreenDeltaPx,
-            _dragView ?? args.View,
-            convertDelta,
-            constrainPosition);
+        ApplyDragPosition(totalScreenDeltaPx, _dragView ?? args.View, convertDelta, constrainPosition);
 
-        dragged(
-            CreateDragEventArgs(args));
+        dragged(CreateDragEventArgs(args));
     }
 
-    internal void ProcessPointerUp(
-        WidgetPointerEventArgs args,
-        Func<Vector2, View, Vector2> convertDelta,
-        Func<Vector2, Vector2> constrainPosition,
-        Action<WidgetDragEventArgs> dragEnded)
+    internal void ProcessPointerUp(WidgetPointerEventArgs args,
+                                   Func<Vector2, View, Vector2> convertDelta,
+                                   Func<Vector2, Vector2> constrainPosition,
+                                   Action<WidgetDragEventArgs> dragEnded)
     {
-        if (!_isPointerDown ||
-            !IsMatchingRelease(args))
-        {
+        if (!_isPointerDown || !IsMatchingRelease(args))
             return;
-        }
 
         WidgetDragEventArgs? dragArgs = null;
 
         if (IsDragging)
         {
-            Vector2 totalScreenDeltaPx =
-                GetTotalScreenDelta(
-                    args.ScreenPositionPx);
+            Vector2 totalScreenDeltaPx = GetTotalScreenDelta(args.ScreenPositionPx);
+            ApplyDragPosition(totalScreenDeltaPx, _dragView ?? args.View, convertDelta, constrainPosition);
 
-            ApplyDragPosition(
-                totalScreenDeltaPx,
-                _dragView ?? args.View,
-                convertDelta,
-                constrainPosition);
-
-            dragArgs =
-                CreateDragEventArgs(args);
+            dragArgs = CreateDragEventArgs(args);
         }
 
         bool completedDrag = IsDragging;
 
         ResetPointerState();
 
-        if (completedDrag &&
-            dragArgs is not null)
+        if (completedDrag && dragArgs is not null)
         {
             _suppressNextPointerClick = true;
             dragEnded(dragArgs);
         }
     }
 
-    internal bool ShouldDispatchPointerClick(
-        WidgetPointerEventArgs args)
+    internal bool ShouldDispatchPointerClick(WidgetPointerEventArgs args)
     {
         if (!_suppressNextPointerClick)
             return true;
@@ -191,32 +147,23 @@ internal sealed class WidgetDragBehavior
         return false;
     }
 
-    internal Vector2 ConvertScreenDeltaToPositionDelta(
-        Vector2 totalScreenDeltaPx,
-        View view)
+    internal Vector2 ConvertScreenDeltaToPositionDelta(Vector2 totalScreenDeltaPx,
+                                                       View view)
     {
         ArgumentNullException.ThrowIfNull(view);
 
         if (_owner.Mode == DirectDrawingMode.View)
             return totalScreenDeltaPx;
 
-        var currentScreenPositionPx = new PointF(
-            _dragStartScreenPositionPx.X +
-            totalScreenDeltaPx.X,
-            _dragStartScreenPositionPx.Y +
-            totalScreenDeltaPx.Y);
+        var currentScreenPositionPx = new PointF(_dragStartScreenPositionPx.X + totalScreenDeltaPx.X,
+                                                 _dragStartScreenPositionPx.Y + totalScreenDeltaPx.Y);
 
-        Vector2 currentPointerPositionPx =
-            GetPointerPositionInWidgetSpace(
-                currentScreenPositionPx,
-                view);
+        Vector2 currentPointerPositionPx = GetPointerPositionInWidgetSpace(currentScreenPositionPx, view);
 
-        return currentPointerPositionPx -
-               _dragStartPointerPositionPx;
+        return currentPointerPositionPx - _dragStartPointerPositionPx;
     }
 
-    internal void ResetPointerState(
-        bool clearClickSuppression = false)
+    internal void ResetPointerState(bool clearClickSuppression = false)
     {
         _isPointerDown = false;
         IsDragging = false;
@@ -231,83 +178,51 @@ internal sealed class WidgetDragBehavior
             _suppressNextPointerClick = false;
     }
 
-    private Vector2 GetPointerPositionInWidgetSpace(
-        PointF screenPositionPx,
-        View view)
+    private Vector2 GetPointerPositionInWidgetSpace(PointF screenPositionPx,
+                                                    View view)
     {
-        if (_owner.Mode ==
-            DirectDrawingMode.View)
-        {
-            return new Vector2(
-                screenPositionPx.X,
-                screenPositionPx.Y);
-        }
+        if (_owner.Mode == DirectDrawingMode.View)
+            return new Vector2(screenPositionPx.X, screenPositionPx.Y);
 
-        var sceneLayer =
-            _owner.SceneLayer ??
-            throw new InvalidOperationException(
-                "A scene-layer draggable widget must contain children attached to a SceneLayer.");
+        var sceneLayer = _owner.SceneLayer
+            ?? throw new InvalidOperationException("A scene-layer draggable widget must contain children attached to a SceneLayer.");
 
-        PointF worldPositionPx =
-            view.ScreenPxToWorldPx(
-                sceneLayer,
-                screenPositionPx);
+        PointF worldPositionPx = view.ScreenPxToWorldPx(sceneLayer, screenPositionPx);
 
-        return new Vector2(
-            worldPositionPx.X,
-            worldPositionPx.Y);
+        return new Vector2(worldPositionPx.X, worldPositionPx.Y);
     }
 
-    private Vector2 GetTotalScreenDelta(
-        PointF currentScreenPositionPx)
+    private Vector2 GetTotalScreenDelta(PointF currentScreenPositionPx)
     {
-        return new Vector2(
-            currentScreenPositionPx.X -
-            _dragStartScreenPositionPx.X,
-            currentScreenPositionPx.Y -
-            _dragStartScreenPositionPx.Y);
+        return new Vector2(currentScreenPositionPx.X - _dragStartScreenPositionPx.X,
+                           currentScreenPositionPx.Y - _dragStartScreenPositionPx.Y);
     }
 
-    private void ApplyDragPosition(
-        Vector2 totalScreenDeltaPx,
-        View view,
-        Func<Vector2, View, Vector2> convertDelta,
-        Func<Vector2, Vector2> constrainPosition)
+    private void ApplyDragPosition(Vector2 totalScreenDeltaPx,
+                                   View view,
+                                   Func<Vector2, View, Vector2> convertDelta,
+                                   Func<Vector2, Vector2> constrainPosition)
     {
-        Vector2 positionDeltaPx =
-            convertDelta(
-                totalScreenDeltaPx,
-                view);
+        Vector2 positionDeltaPx = convertDelta(totalScreenDeltaPx, view);
+        Vector2 proposedPositionPx = _dragStartWidgetPositionPx + positionDeltaPx;
 
-        Vector2 proposedPositionPx =
-            _dragStartWidgetPositionPx +
-            positionDeltaPx;
-
-        _owner.SetPosition(
-            constrainPosition(
-                proposedPositionPx));
+        _owner.SetPosition(constrainPosition(proposedPositionPx));
     }
 
-    private bool IsMatchingRelease(
-        WidgetPointerEventArgs args)
+    private bool IsMatchingRelease(WidgetPointerEventArgs args)
     {
-        return args.PointerId ==
-               _dragPointerId &&
-               (args.Button ==
-                    WidgetPointerButtonEnum.None ||
-                args.Button ==
-                    _dragButton);
+        return args.PointerId == _dragPointerId &&
+               (args.Button == WidgetPointerButtonEnum.None ||
+                args.Button == _dragButton);
     }
 
-    private WidgetDragEventArgs CreateDragEventArgs(
-        WidgetPointerEventArgs pointerArgs)
+    private WidgetDragEventArgs CreateDragEventArgs(WidgetPointerEventArgs pointerArgs)
     {
-        return new WidgetDragEventArgs(
-            _owner,
-            _dragStartScreenPositionPx,
-            pointerArgs.ScreenPositionPx,
-            _dragButton,
-            pointerArgs.Tick,
-            pointerArgs.PointerId);
+        return new WidgetDragEventArgs(_owner,
+                                       _dragStartScreenPositionPx,
+                                       pointerArgs.ScreenPositionPx,
+                                       _dragButton,
+                                       pointerArgs.Tick,
+                                       pointerArgs.PointerId);
     }
 }

--- a/Gondwana.Widgets/WidgetDragEventArgs.cs
+++ b/Gondwana.Widgets/WidgetDragEventArgs.cs
@@ -17,13 +17,12 @@ public sealed class WidgetDragEventArgs : WidgetEventArgs
     /// <param name="button">The pointer button used for dragging.</param>
     /// <param name="tick">The engine tick associated with the event.</param>
     /// <param name="pointerId">The identifier of the pointer performing the drag.</param>
-    public WidgetDragEventArgs(
-        WidgetBase widget,
-        PointF startScreenPositionPx,
-        PointF currentScreenPositionPx,
-        WidgetPointerButtonEnum button = WidgetPointerButtonEnum.Left,
-        long tick = 0,
-        int pointerId = 0)
+    public WidgetDragEventArgs(WidgetBase widget,
+                               PointF startScreenPositionPx,
+                               PointF currentScreenPositionPx,
+                               WidgetPointerButtonEnum button = WidgetPointerButtonEnum.Left,
+                               long tick = 0,
+                               int pointerId = 0)
         : base(widget, tick)
     {
         StartScreenPositionPx = startScreenPositionPx;
@@ -55,7 +54,6 @@ public sealed class WidgetDragEventArgs : WidgetEventArgs
     /// <summary>
     /// Gets the total drag offset from the drag start position.
     /// </summary>
-    public Vector2 TotalDeltaPx => new(
-        CurrentScreenPositionPx.X - StartScreenPositionPx.X,
-        CurrentScreenPositionPx.Y - StartScreenPositionPx.Y);
+    public Vector2 TotalDeltaPx => new(CurrentScreenPositionPx.X - StartScreenPositionPx.X,
+                                       CurrentScreenPositionPx.Y - StartScreenPositionPx.Y);
 }

--- a/Gondwana.Widgets/WidgetInputRouter.cs
+++ b/Gondwana.Widgets/WidgetInputRouter.cs
@@ -1,11 +1,11 @@
-﻿using Gondwana.Drawing.Direct;
+﻿using System.Drawing;
+using System.Numerics;
+using Gondwana.Drawing.Direct;
 using Gondwana.Input.Keyboard;
 using Gondwana.Input.Mouse;
 using Gondwana.Input.Touch;
 using Gondwana.Rendering;
 using Gondwana.Rendering.Views;
-using System.Drawing;
-using System.Numerics;
 
 namespace Gondwana.Widgets;
 
@@ -49,15 +49,12 @@ public sealed class WidgetInputRouter : IDisposable
     /// <param name="keyboardEventPoller">The keyboard event poller that supplies keyboard input, or <see langword="null"/>.</param>
     /// <param name="mouseEventPoller">The mouse event poller that supplies mouse input, or <see langword="null"/>.</param>
     /// <param name="touchEventPoller">The touch event poller that supplies touch input, or <see langword="null"/>.</param>
-    public WidgetInputRouter(
-        RenderSurfaceHostBase renderSurfaceHost,
-        KeyboardEventPoller? keyboardEventPoller,
-        MouseEventPoller? mouseEventPoller,
-        TouchEventPoller? touchEventPoller)
+    public WidgetInputRouter(RenderSurfaceHostBase renderSurfaceHost,
+                             KeyboardEventPoller? keyboardEventPoller,
+                             MouseEventPoller? mouseEventPoller,
+                             TouchEventPoller? touchEventPoller)
     {
-        _renderSurfaceHost =
-            renderSurfaceHost ??
-            throw new ArgumentNullException(nameof(renderSurfaceHost));
+        _renderSurfaceHost = renderSurfaceHost ?? throw new ArgumentNullException(nameof(renderSurfaceHost));
 
         _keyboardEventPoller = keyboardEventPoller;
         _mouseEventPoller = mouseEventPoller;
@@ -83,9 +80,7 @@ public sealed class WidgetInputRouter : IDisposable
 
         if (!ReferenceEquals(widget.RenderSurfaceHost, _renderSurfaceHost))
         {
-            throw new ArgumentException(
-                "The widget belongs to a different RenderSurfaceHost.",
-                nameof(widget));
+            throw new ArgumentException("The widget belongs to a different RenderSurfaceHost.", nameof(widget));
         }
 
         lock (_syncRoot)
@@ -283,13 +278,11 @@ public sealed class WidgetInputRouter : IDisposable
         if (!int.TryParse(args.KeyConfig.Key, out int key))
             return;
 
-        target.DispatchKeyboardInput(
-            new WidgetKeyboardEventArgs(
-                target,
-                key,
-                args.KeyAction,
-                args.Modifiers,
-                tick: 0));
+        target.DispatchKeyboardInput(new WidgetKeyboardEventArgs(target,
+                                                                 key,
+                                                                 args.KeyAction,
+                                                                 args.Modifiers,
+                                                                 tick: 0));
     }
 
     private void OnMouseEvent(MouseEventArgs args)
@@ -300,240 +293,172 @@ public sealed class WidgetInputRouter : IDisposable
         Point currentPosition = args.CurrentPosition;
         WidgetHit? initialHit = HitTest(currentPosition);
 
-        UpdateMouseHover(
-            initialHit,
-            currentPosition,
-            args.Tick);
+        UpdateMouseHover(initialHit, currentPosition, args.Tick);
 
         foreach (MouseButton mouseButton in _mouseButtons)
         {
             if (args.IsButtonJustPressed(mouseButton))
             {
-                ProcessMouseDown(
-                    initialHit,
-                    currentPosition,
-                    mouseButton,
-                    args.Tick);
+                ProcessMouseDown(initialHit, currentPosition, mouseButton, args.Tick);
             }
         }
 
         if (args.PreviousPosition != currentPosition)
         {
-            ProcessMouseMove(
-                args.PreviousPosition,
-                currentPosition,
-                args.Tick);
+            ProcessMouseMove(args.PreviousPosition, currentPosition, args.Tick);
         }
 
         foreach (MouseButton mouseButton in _mouseButtons)
         {
             if (args.IsButtonJustReleased(mouseButton))
             {
-                ProcessMouseUp(
-                    currentPosition,
-                    mouseButton,
-                    args.Tick);
+                ProcessMouseUp(currentPosition, mouseButton, args.Tick);
             }
         }
 
-        UpdateMouseHover(
-            HitTest(currentPosition),
-            currentPosition,
-            args.Tick);
+        UpdateMouseHover(HitTest(currentPosition), currentPosition, args.Tick);
     }
 
-    private void ProcessMouseDown(
-        WidgetHit? hit,
-        Point position,
-        MouseButton mouseButton,
-        long tick)
+    private void ProcessMouseDown(WidgetHit? hit,
+                                  Point position,
+                                  MouseButton mouseButton,
+                                  long tick)
     {
         if (_mouseCapture is not null || hit is null)
             return;
 
         FocusFromPointer(hit.Widget);
 
-        WidgetPointerButtonEnum widgetButton =
-            MapMouseButton(mouseButton);
+        WidgetPointerButtonEnum widgetButton = MapMouseButton(mouseButton);
 
-        hit.Widget.DispatchPointerDown(
-            CreatePointerArgs(
-                hit.Widget,
-                hit.View,
-                position,
-                widgetButton,
-                tick,
-                MousePointerId));
+        hit.Widget.DispatchPointerDown(CreatePointerArgs(hit.Widget,
+                                                         hit.View,
+                                                         position,
+                                                         widgetButton,
+                                                         tick,
+                                                         MousePointerId));
 
-        _mouseCapture = new PointerCapture(
-            hit.Widget,
-            hit.View,
-            widgetButton,
-            position);
+        _mouseCapture = new PointerCapture(hit.Widget,
+                                           hit.View,
+                                           widgetButton,
+                                           position);
     }
 
-    private void ProcessMouseMove(
-        Point previousPosition,
-        Point currentPosition,
-        long tick)
+    private void ProcessMouseMove(Point previousPosition,
+                                  Point currentPosition,
+                                  long tick)
     {
-        PointerCapture? capture =
-            GetValidMouseCapture(tick);
-
-        WidgetHit? hit =
-            capture is null
-                ? HitTest(currentPosition)
-                : null;
-
-        WidgetBase? recipient =
-            capture?.Widget ?? hit?.Widget;
-
-        View? view =
-            capture?.View ?? hit?.View;
+        PointerCapture? capture = GetValidMouseCapture(tick);
+        WidgetHit? hit = capture is null ? HitTest(currentPosition) : null;
+        WidgetBase? recipient = capture?.Widget ?? hit?.Widget;
+        View? view = capture?.View ?? hit?.View;
 
         if (recipient is null || view is null)
             return;
 
-        var delta = new Vector2(
-            currentPosition.X - previousPosition.X,
-            currentPosition.Y - previousPosition.Y);
+        var delta = new Vector2(currentPosition.X - previousPosition.X,
+                                currentPosition.Y - previousPosition.Y);
 
-        WidgetPointerButtonEnum button =
-            capture?.Button ??
-            WidgetPointerButtonEnum.None;
+        WidgetPointerButtonEnum button = capture?.Button ?? WidgetPointerButtonEnum.None;
 
-        recipient.DispatchPointerMove(
-            CreatePointerArgs(
-                recipient,
-                view,
-                currentPosition,
-                button,
-                tick,
-                MousePointerId,
-                deltaPx: delta));
+        recipient.DispatchPointerMove(CreatePointerArgs(recipient,
+                                                        view,
+                                                        currentPosition,
+                                                        button,
+                                                        tick,
+                                                        MousePointerId,
+                                                        deltaPx: delta));
 
         if (capture is not null)
             capture.LastPosition = currentPosition;
     }
 
-    private void ProcessMouseUp(
-        Point position,
-        MouseButton mouseButton,
-        long tick)
+    private void ProcessMouseUp(Point position,
+                                MouseButton mouseButton,
+                                long tick)
     {
-        WidgetPointerButtonEnum releasedButton =
-            MapMouseButton(mouseButton);
+        WidgetPointerButtonEnum releasedButton = MapMouseButton(mouseButton);
+        PointerCapture? capture = GetValidMouseCapture(tick);
 
-        PointerCapture? capture =
-            GetValidMouseCapture(tick);
-
-        if (capture is null ||
-            capture.Button != releasedButton)
-        {
+        if (capture is null || capture.Button != releasedButton)
             return;
-        }
 
         WidgetBase recipient = capture.Widget;
 
-        recipient.DispatchPointerUp(
-            CreatePointerArgs(
-                recipient,
-                capture.View,
-                position,
-                releasedButton,
-                tick,
-                MousePointerId));
+        recipient.DispatchPointerUp(CreatePointerArgs(recipient,
+                                                      capture.View,
+                                                      position,
+                                                      releasedButton,
+                                                      tick,
+                                                      MousePointerId));
 
         WidgetHit? releaseHit = HitTest(position);
 
-        if (IsSameHit(
-            releaseHit,
-            recipient,
-            capture.View))
+        if (IsSameHit(releaseHit, recipient, capture.View))
         {
-            recipient.DispatchPointerClick(
-                CreatePointerArgs(
-                    recipient,
-                    capture.View,
-                    position,
-                    releasedButton,
-                    tick,
-                    MousePointerId,
-                    clickCount: 1));
+            recipient.DispatchPointerClick(CreatePointerArgs(recipient,
+                                                             capture.View,
+                                                             position,
+                                                             releasedButton,
+                                                             tick,
+                                                             MousePointerId,
+                                                             clickCount: 1));
         }
 
         _mouseCapture = null;
     }
 
-    private void UpdateMouseHover(
-        WidgetHit? hit,
-        Point position,
-        long tick)
+    private void UpdateMouseHover(WidgetHit? hit,
+                                  Point position,
+                                  long tick)
     {
-        if (IsSameHit(
-            _hoveredHit,
-            hit))
-        {
+        if (IsSameHit(_hoveredHit, hit))
             return;
-        }
 
         WidgetHit? previous = _hoveredHit;
         _hoveredHit = hit;
 
         if (previous is not null)
         {
-            previous.Widget.DispatchPointerLeave(
-                CreatePointerArgs(
-                    previous.Widget,
-                    previous.View,
-                    position,
-                    WidgetPointerButtonEnum.None,
-                    tick,
-                    MousePointerId));
+            previous.Widget.DispatchPointerLeave(CreatePointerArgs(previous.Widget,
+                                                                   previous.View,
+                                                                   position,
+                                                                   WidgetPointerButtonEnum.None,
+                                                                   tick,
+                                                                   MousePointerId));
         }
 
         if (hit is not null)
         {
-            hit.Widget.DispatchPointerEnter(
-                CreatePointerArgs(
-                    hit.Widget,
-                    hit.View,
-                    position,
-                    WidgetPointerButtonEnum.None,
-                    tick,
-                    MousePointerId));
+            hit.Widget.DispatchPointerEnter(CreatePointerArgs(hit.Widget,
+                                                              hit.View,
+                                                              position,
+                                                              WidgetPointerButtonEnum.None,
+                                                              tick,
+                                                              MousePointerId));
         }
     }
 
-    private PointerCapture? GetValidMouseCapture(
-        long tick)
+    private PointerCapture? GetValidMouseCapture(long tick)
     {
         if (_mouseCapture is null)
             return null;
 
-        if (IsPointerRoutable(
-            _mouseCapture.Widget,
-            _mouseCapture.View))
-        {
+        if (IsPointerRoutable(_mouseCapture.Widget, _mouseCapture.View))
             return _mouseCapture;
-        }
 
-        _mouseCapture.Widget.DispatchPointerUp(
-            CreatePointerArgs(
-                _mouseCapture.Widget,
-                _mouseCapture.View,
-                _mouseCapture.LastPosition,
-                _mouseCapture.Button,
-                tick,
-                MousePointerId));
+        _mouseCapture.Widget.DispatchPointerUp(CreatePointerArgs(_mouseCapture.Widget,
+                                                                 _mouseCapture.View,
+                                                                 _mouseCapture.LastPosition,
+                                                                 _mouseCapture.Button,
+                                                                 tick,
+                                                                 MousePointerId));
 
         _mouseCapture = null;
         return null;
     }
 
-    private void OnTouchBegan(
-        object? sender,
-        TouchEventArgs args)
+    private void OnTouchBegan(object? sender, TouchEventArgs args)
     {
         if (!_isStarted || _disposed)
             return;
@@ -543,134 +468,99 @@ public sealed class WidgetInputRouter : IDisposable
         if (_touchCaptures.ContainsKey(touch.Id))
             return;
 
-        WidgetHit? hit =
-            HitTest(touch.Position);
+        WidgetHit? hit = HitTest(touch.Position);
 
         if (hit is null)
             return;
 
         FocusFromPointer(hit.Widget);
 
-        hit.Widget.DispatchPointerDown(
-            CreatePointerArgs(
-                hit.Widget,
-                hit.View,
-                touch.Position,
-                WidgetPointerButtonEnum.Touch,
-                args.Tick,
-                touch.Id));
+        hit.Widget.DispatchPointerDown(CreatePointerArgs(hit.Widget,
+                                                         hit.View,
+                                                         touch.Position,
+                                                         WidgetPointerButtonEnum.Touch,
+                                                         args.Tick,
+                                                         touch.Id));
 
-        _touchCaptures[touch.Id] =
-            new PointerCapture(
-                hit.Widget,
-                hit.View,
-                WidgetPointerButtonEnum.Touch,
-                touch.Position);
+        _touchCaptures[touch.Id] = new PointerCapture(hit.Widget,
+                                                      hit.View,
+                                                      WidgetPointerButtonEnum.Touch,
+                                                      touch.Position);
     }
 
-    private void OnTouchMoved(
-        object? sender,
-        TouchEventArgs args)
+    private void OnTouchMoved(object? sender, TouchEventArgs args)
     {
         if (!_isStarted || _disposed)
             return;
 
         TouchPoint touch = args.Touch;
 
-        if (!_touchCaptures.TryGetValue(
-            touch.Id,
-            out PointerCapture? capture))
-        {
+        if (!_touchCaptures.TryGetValue(touch.Id, out PointerCapture? capture))
             return;
-        }
 
-        if (!IsPointerRoutable(
-            capture.Widget,
-            capture.View))
+        if (!IsPointerRoutable(capture.Widget, capture.View))
         {
-            capture.Widget.DispatchPointerUp(
-                CreatePointerArgs(
-                    capture.Widget,
-                    capture.View,
-                    capture.LastPosition,
-                    WidgetPointerButtonEnum.Touch,
-                    args.Tick,
-                    touch.Id));
+            capture.Widget.DispatchPointerUp(CreatePointerArgs(capture.Widget,
+                                                               capture.View,
+                                                               capture.LastPosition,
+                                                               WidgetPointerButtonEnum.Touch,
+                                                               args.Tick,
+                                                               touch.Id));
 
             _touchCaptures.Remove(touch.Id);
             return;
         }
 
-        var delta = new Vector2(
-            touch.Position.X - capture.LastPosition.X,
-            touch.Position.Y - capture.LastPosition.Y);
+        var delta = new Vector2(touch.Position.X - capture.LastPosition.X,
+                                touch.Position.Y - capture.LastPosition.Y);
 
-        capture.Widget.DispatchPointerMove(
-            CreatePointerArgs(
-                capture.Widget,
-                capture.View,
-                touch.Position,
-                WidgetPointerButtonEnum.Touch,
-                args.Tick,
-                touch.Id,
-                deltaPx: delta));
+        capture.Widget.DispatchPointerMove(CreatePointerArgs(capture.Widget,
+                                                             capture.View,
+                                                             touch.Position,
+                                                             WidgetPointerButtonEnum.Touch,
+                                                             args.Tick,
+                                                             touch.Id,
+                                                             deltaPx: delta));
 
         capture.LastPosition = touch.Position;
     }
 
-    private void OnTouchEnded(
-        object? sender,
-        TouchEventArgs args)
+    private void OnTouchEnded(object? sender, TouchEventArgs args)
     {
         if (!_isStarted || _disposed)
             return;
 
         TouchPoint touch = args.Touch;
 
-        if (!_touchCaptures.Remove(
-            touch.Id,
-            out PointerCapture? capture))
-        {
+        if (!_touchCaptures.Remove(touch.Id, out PointerCapture? capture))
             return;
-        }
 
         WidgetBase recipient = capture.Widget;
 
-        recipient.DispatchPointerUp(
-            CreatePointerArgs(
-                recipient,
-                capture.View,
-                touch.Position,
-                WidgetPointerButtonEnum.Touch,
-                args.Tick,
-                touch.Id));
+        recipient.DispatchPointerUp(CreatePointerArgs(recipient,
+                                                      capture.View,
+                                                      touch.Position,
+                                                      WidgetPointerButtonEnum.Touch,
+                                                      args.Tick,
+                                                      touch.Id));
 
-        WidgetHit? releaseHit =
-            HitTest(touch.Position);
+        WidgetHit? releaseHit = HitTest(touch.Position);
 
-        if (touch.Phase != TouchPhase.Cancelled &&
-            IsSameHit(
-                releaseHit,
-                recipient,
-                capture.View))
+        if (touch.Phase != TouchPhase.Cancelled && IsSameHit(releaseHit, recipient, capture.View))
         {
-            recipient.DispatchPointerClick(
-                CreatePointerArgs(
-                    recipient,
-                    capture.View,
-                    touch.Position,
-                    WidgetPointerButtonEnum.Touch,
-                    args.Tick,
-                    touch.Id,
-                    clickCount: 1));
+            recipient.DispatchPointerClick(CreatePointerArgs(recipient,
+                                                             capture.View,
+                                                             touch.Position,
+                                                             WidgetPointerButtonEnum.Touch,
+                                                             args.Tick,
+                                                             touch.Id,
+                                                             clickCount: 1));
         }
     }
 
-    private WidgetHit? HitTest(
-        Point screenPositionPx)
+    private WidgetHit? HitTest(Point screenPositionPx)
     {
-        View? view =
-            GetTopmostViewAt(screenPositionPx);
+        View? view = GetTopmostViewAt(screenPositionPx);
 
         if (view is null)
             return null;
@@ -680,106 +570,71 @@ public sealed class WidgetInputRouter : IDisposable
         lock (_syncRoot)
             snapshot = [.. _widgets];
 
-        for (int index = snapshot.Length - 1;
-             index >= 0;
-             index--)
+        for (int index = snapshot.Length - 1; index >= 0; index--)
         {
             WidgetBase widget = snapshot[index];
 
-            if (widget.HitTest(
-                view,
-                screenPositionPx))
-            {
-                return new WidgetHit(
-                    widget,
-                    view);
-            }
+            if (widget.HitTest(view, screenPositionPx))
+                return new WidgetHit(widget, view);
         }
 
         return null;
     }
 
-    private View? GetTopmostViewAt(
-        Point screenPositionPx)
+    private View? GetTopmostViewAt(Point screenPositionPx)
     {
-        var views =
-            _renderSurfaceHost.ViewManager.Views;
+        var views = _renderSurfaceHost.ViewManager.Views;
 
-        for (int index = views.Count - 1;
-             index >= 0;
-             index--)
+        for (int index = views.Count - 1; index >= 0; index--)
         {
             View view = views[index];
 
-            if (view.Viewport.TargetRectPx.Contains(
-                screenPositionPx))
-            {
+            if (view.Viewport.TargetRectPx.Contains(screenPositionPx))
                 return view;
-            }
         }
 
         return null;
     }
 
-    private bool IsRegistered(
-        WidgetBase widget)
+    private bool IsRegistered(WidgetBase widget)
     {
         lock (_syncRoot)
             return _widgets.Contains(widget);
     }
 
-    private bool IsManagedView(
-        View view)
+    private bool IsManagedView(View view)
     {
-        return _renderSurfaceHost
-            .ViewManager
-            .Views
-            .Contains(view);
+        return _renderSurfaceHost.ViewManager.Views.Contains(view);
     }
 
-    private bool HasValidTarget(
-        WidgetBase widget,
-        View? routedView = null)
+    private bool HasValidTarget(WidgetBase widget,
+                                View? routedView = null)
     {
         if (widget.Mode == DirectDrawingMode.SceneLayer)
             return widget.SceneLayer is not null;
 
-        if (widget.View is null ||
-            !IsManagedView(widget.View))
-        {
+        if (widget.View is null || !IsManagedView(widget.View))
             return false;
-        }
 
-        return routedView is null ||
-               ReferenceEquals(
-                   widget.View,
-                   routedView);
+        return routedView is null || ReferenceEquals(widget.View, routedView);
     }
 
-    private bool IsPointerRoutable(
-        WidgetBase widget,
-        View view)
+    private bool IsPointerRoutable(WidgetBase widget,
+                                   View view)
     {
         return IsRegistered(widget) &&
                IsManagedView(view) &&
-               ReferenceEquals(
-                   widget.RenderSurfaceHost,
-                   _renderSurfaceHost) &&
-               HasValidTarget(
-                   widget,
-                   view) &&
+               ReferenceEquals(widget.RenderSurfaceHost, _renderSurfaceHost) &&
+               HasValidTarget(widget, view) &&
                widget.IsInputEnabled &&
                widget.IsPointerInputEnabled &&
                widget.Visible;
     }
 
-    private bool CanReceiveKeyboardInput(
-        WidgetBase widget)
+    private bool CanReceiveKeyboardInput(WidgetBase widget)
     {
         return IsRegistered(widget) &&
-               ReferenceEquals(
-                   widget.RenderSurfaceHost,
-                   _renderSurfaceHost) &&
+               ReferenceEquals(widget.RenderSurfaceHost, _renderSurfaceHost) &&
                HasValidTarget(widget) &&
                widget.Visible &&
                widget.IsInputEnabled &&
@@ -787,8 +642,7 @@ public sealed class WidgetInputRouter : IDisposable
                widget.CanReceiveFocus;
     }
 
-    private void FocusFromPointer(
-        WidgetBase widget)
+    private void FocusFromPointer(WidgetBase widget)
     {
         if (widget.IsInputEnabled &&
             widget.IsKeyboardInputEnabled &&
@@ -809,165 +663,116 @@ public sealed class WidgetInputRouter : IDisposable
         ReleaseKeyboardFocus(widget);
     }
 
-    private void ReleasePointerState(
-        WidgetBase widget,
-        bool dispatchPointerUp)
+    private void ReleasePointerState(WidgetBase widget,
+                                     bool dispatchPointerUp)
     {
-        if (ReferenceEquals(
-            _hoveredHit?.Widget,
-            widget))
-        {
+        if (ReferenceEquals(_hoveredHit?.Widget, widget))
             _hoveredHit = null;
-        }
 
-        if (ReferenceEquals(
-            _mouseCapture?.Widget,
-            widget))
+        if (ReferenceEquals(_mouseCapture?.Widget, widget))
         {
-            PointerCapture capture =
-                _mouseCapture;
+            PointerCapture capture = _mouseCapture;
 
             if (dispatchPointerUp)
             {
-                widget.DispatchPointerUp(
-                    CreatePointerArgs(
-                        widget,
-                        capture.View,
-                        capture.LastPosition,
-                        capture.Button,
-                        tick: 0,
-                        pointerId: MousePointerId));
+                widget.DispatchPointerUp(CreatePointerArgs(widget,
+                                                           capture.View,
+                                                           capture.LastPosition,
+                                                           capture.Button,
+                                                           tick: 0,
+                                                           pointerId: MousePointerId));
             }
 
             _mouseCapture = null;
         }
 
-        int[] touchIds = _touchCaptures
-            .Where(x =>
-                ReferenceEquals(
-                    x.Value.Widget,
-                    widget))
-            .Select(x => x.Key)
-            .ToArray();
+        int[] touchIds = _touchCaptures.Where(x => ReferenceEquals(x.Value.Widget, widget))
+                                       .Select(x => x.Key)
+                                       .ToArray();
 
         foreach (int touchId in touchIds)
         {
-            PointerCapture capture =
-                _touchCaptures[touchId];
+            PointerCapture capture = _touchCaptures[touchId];
 
             if (dispatchPointerUp)
             {
-                widget.DispatchPointerUp(
-                    CreatePointerArgs(
-                        widget,
-                        capture.View,
-                        capture.LastPosition,
-                        WidgetPointerButtonEnum.Touch,
-                        tick: 0,
-                        pointerId: touchId));
+                widget.DispatchPointerUp(CreatePointerArgs(widget,
+                                                           capture.View,
+                                                           capture.LastPosition,
+                                                           WidgetPointerButtonEnum.Touch,
+                                                           tick: 0,
+                                                           pointerId: touchId));
             }
 
             _touchCaptures.Remove(touchId);
         }
     }
 
-    private void ReleaseKeyboardFocus(
-        WidgetBase widget)
+    private void ReleaseKeyboardFocus(WidgetBase widget)
     {
-        if (ReferenceEquals(
-            _focusedWidget,
-            widget))
-        {
+        if (ReferenceEquals(_focusedWidget, widget))
             Focus(null);
-        }
     }
 
-    private static bool IsSameHit(
-        WidgetHit? left,
-        WidgetHit? right)
+    private static bool IsSameHit(WidgetHit? left,
+                                  WidgetHit? right)
     {
         if (left is null || right is null)
             return left is null && right is null;
 
-        return ReferenceEquals(
-                   left.Widget,
-                   right.Widget) &&
-               ReferenceEquals(
-                   left.View,
-                   right.View);
+        return ReferenceEquals(left.Widget, right.Widget)
+            && ReferenceEquals(left.View, right.View);
     }
 
-    private static bool IsSameHit(
-        WidgetHit? hit,
-        WidgetBase widget,
-        View view)
+    private static bool IsSameHit(WidgetHit? hit,
+                                  WidgetBase widget,
+                                  View view)
     {
-        return hit is not null &&
-               ReferenceEquals(
-                   hit.Widget,
-                   widget) &&
-               ReferenceEquals(
-                   hit.View,
-                   view);
+        return hit is not null
+            && ReferenceEquals(hit.Widget, widget)
+            && ReferenceEquals(hit.View, view);
     }
 
-    private static WidgetPointerEventArgs CreatePointerArgs(
-        WidgetBase widget,
-        View view,
-        Point position,
-        WidgetPointerButtonEnum button,
-        long tick,
-        int pointerId,
-        int clickCount = 0,
-        Vector2 deltaPx = default)
+    private static WidgetPointerEventArgs CreatePointerArgs(WidgetBase widget,
+                                                            View view,
+                                                            Point position,
+                                                            WidgetPointerButtonEnum button,
+                                                            long tick,
+                                                            int pointerId,
+                                                            int clickCount = 0,
+                                                            Vector2 deltaPx = default)
     {
-        return new WidgetPointerEventArgs(
-            widget,
-            view,
-            new PointF(
-                position.X,
-                position.Y),
-            button,
-            clickCount,
-            deltaPx,
-            tick,
-            pointerId);
+        return new WidgetPointerEventArgs(widget,
+                                          view,
+                                          new PointF(position.X, position.Y),
+                                          button,
+                                          clickCount,
+                                          deltaPx,
+                                          tick,
+                                          pointerId);
     }
 
-    private static WidgetPointerButtonEnum MapMouseButton(
-        MouseButton button)
+    private static WidgetPointerButtonEnum MapMouseButton(MouseButton button)
     {
         return button switch
         {
-            MouseButton.Left =>
-                WidgetPointerButtonEnum.Left,
-
-            MouseButton.Right =>
-                WidgetPointerButtonEnum.Right,
-
-            MouseButton.Middle =>
-                WidgetPointerButtonEnum.Middle,
-
-            _ =>
-                WidgetPointerButtonEnum.None
+            MouseButton.Left => WidgetPointerButtonEnum.Left,
+            MouseButton.Right => WidgetPointerButtonEnum.Right,
+            MouseButton.Middle => WidgetPointerButtonEnum.Middle,
+            _ => WidgetPointerButtonEnum.None
         };
     }
 
-    private void OnWidgetDisposing(
-        object? sender,
-        IDirectDrawable drawing)
+    private void OnWidgetDisposing(object? sender, IDirectDrawable drawing)
     {
         if (drawing is WidgetBase widget)
         {
-            Unregister(
-                widget,
-                dispatchPointerUp: false);
+            Unregister(widget, dispatchPointerUp: false);
         }
     }
 
-    private void Unregister(
-        WidgetBase widget,
-        bool dispatchPointerUp)
+    private void Unregister(WidgetBase widget,
+                            bool dispatchPointerUp)
     {
         bool removed;
 
@@ -979,9 +784,7 @@ public sealed class WidgetInputRouter : IDisposable
 
         widget.Disposing -= OnWidgetDisposing;
 
-        ReleaseInputState(
-            widget,
-            dispatchPointerUp);
+        ReleaseInputState(widget, dispatchPointerUp);
     }
 
     private sealed class WidgetHit
@@ -991,9 +794,8 @@ public sealed class WidgetInputRouter : IDisposable
         /// </summary>
         /// <param name="widget">The widget that was hit.</param>
         /// <param name="view">The view in which the widget was hit.</param>
-        public WidgetHit(
-            WidgetBase widget,
-            View view)
+        public WidgetHit(WidgetBase widget,
+                         View view)
         {
             Widget = widget;
             View = view;
@@ -1019,11 +821,10 @@ public sealed class WidgetInputRouter : IDisposable
         /// <param name="view">The view associated with the captured pointer event.</param>
         /// <param name="button">The button associated with the captured pointer.</param>
         /// <param name="lastPosition">The last known pointer position.</param>
-        public PointerCapture(
-            WidgetBase widget,
-            View view,
-            WidgetPointerButtonEnum button,
-            Point lastPosition)
+        public PointerCapture(WidgetBase widget,
+                              View view,
+                              WidgetPointerButtonEnum button,
+                              Point lastPosition)
         {
             Widget = widget;
             View = view;

--- a/Gondwana.Widgets/WidgetInputRouterRegistry.cs
+++ b/Gondwana.Widgets/WidgetInputRouterRegistry.cs
@@ -6,12 +6,9 @@ internal static class WidgetInputRouterRegistry
 {
     private static readonly object _syncRoot = new();
 
-    private static readonly Dictionary<RenderSurfaceHostBase, WidgetInputRouter> _routers =
-        new(ReferenceEqualityComparer.Instance);
+    private static readonly Dictionary<RenderSurfaceHostBase, WidgetInputRouter> _routers = new(ReferenceEqualityComparer.Instance);
 
-    internal static void Attach(
-        RenderSurfaceHostBase renderSurfaceHost,
-        WidgetInputRouter router)
+    internal static void Attach(RenderSurfaceHostBase renderSurfaceHost, WidgetInputRouter router)
     {
         ArgumentNullException.ThrowIfNull(renderSurfaceHost);
         ArgumentNullException.ThrowIfNull(router);
@@ -21,17 +18,14 @@ internal static class WidgetInputRouterRegistry
             if (_routers.TryGetValue(renderSurfaceHost, out WidgetInputRouter? existing) &&
                 !ReferenceEquals(existing, router))
             {
-                throw new InvalidOperationException(
-                    "A widget input router is already attached to this render surface host.");
+                throw new InvalidOperationException("A widget input router is already attached to this render surface host.");
             }
 
             _routers[renderSurfaceHost] = router;
         }
     }
 
-    internal static void Detach(
-        RenderSurfaceHostBase renderSurfaceHost,
-        WidgetInputRouter router)
+    internal static void Detach(RenderSurfaceHostBase renderSurfaceHost, WidgetInputRouter router)
     {
         lock (_syncRoot)
         {
@@ -97,10 +91,7 @@ internal static class WidgetInputRouterRegistry
 
         lock (_syncRoot)
         {
-            _routers.TryGetValue(
-                widget.RenderSurfaceHost,
-                out WidgetInputRouter? router);
-
+            _routers.TryGetValue(widget.RenderSurfaceHost, out WidgetInputRouter? router);
             return router;
         }
     }

--- a/Gondwana.Widgets/WidgetKeyboardEventArgs.cs
+++ b/Gondwana.Widgets/WidgetKeyboardEventArgs.cs
@@ -15,12 +15,11 @@ public sealed class WidgetKeyboardEventArgs : WidgetEventArgs
     /// <param name="keyAction">The key action (pressed, released, repeated).</param>
     /// <param name="modifiers">The keyboard modifier state at the time of the event.</param>
     /// <param name="tick">The engine tick at which the event was emitted.</param>
-    public WidgetKeyboardEventArgs(
-        WidgetBase widget,
-        int key,
-        KeyAction keyAction,
-        KeyboardModifierState modifiers,
-        long tick = 0)
+    public WidgetKeyboardEventArgs(WidgetBase widget,
+                                   int key,
+                                   KeyAction keyAction,
+                                   KeyboardModifierState modifiers,
+                                   long tick = 0)
         : base(widget, tick)
     {
         Key = key;

--- a/Gondwana.Widgets/WidgetPointerEventArgs.cs
+++ b/Gondwana.Widgets/WidgetPointerEventArgs.cs
@@ -23,15 +23,14 @@ public sealed class WidgetPointerEventArgs : WidgetEventArgs
     /// The identifier of the pointer that produced the event. Mouse input uses
     /// <see cref="WidgetInputRouter.MousePointerId"/>; touch input uses its contact ID.
     /// </param>
-    public WidgetPointerEventArgs(
-        WidgetBase widget,
-        View view,
-        PointF screenPositionPx,
-        WidgetPointerButtonEnum button = WidgetPointerButtonEnum.None,
-        int clickCount = 0,
-        Vector2 deltaPx = default,
-        long tick = 0,
-        int pointerId = 0)
+    public WidgetPointerEventArgs(WidgetBase widget,
+                                  View view,
+                                  PointF screenPositionPx,
+                                  WidgetPointerButtonEnum button = WidgetPointerButtonEnum.None,
+                                  int clickCount = 0,
+                                  Vector2 deltaPx = default,
+                                  long tick = 0,
+                                  int pointerId = 0)
         : base(widget, tick)
     {
         View = view ?? throw new ArgumentNullException(nameof(view));

--- a/Gondwana.WinForms/Input/Mouse/WinFormsMouseAdapter.cs
+++ b/Gondwana.WinForms/Input/Mouse/WinFormsMouseAdapter.cs
@@ -6,8 +6,9 @@ namespace Gondwana.WinForms.Input.Mouse;
 /// <summary>
 /// Provides a mouse input adapter for WinForms applications, tracking mouse position, button states, and scroll events.
 /// </summary>
-public sealed class WinFormsMouseAdapter : IMouseAdapter
+public sealed class WinFormsMouseAdapter : IMouseAdapter, IDisposable
 {
+    private readonly Control _control;
     private readonly HashSet<MouseButton> _pressed = new();
     private readonly object _pressedLock = new();
     private Point _currentPosition;
@@ -57,13 +58,12 @@ public sealed class WinFormsMouseAdapter : IMouseAdapter
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="control"/> is <see langword="null"/>.</exception>
     public WinFormsMouseAdapter(Control control)
     {
-        if (control == null)
-            throw new ArgumentNullException(nameof(control));
+        _control = control ?? throw new ArgumentNullException(nameof(control));
 
-        control.MouseDown += OnMouseDown;
-        control.MouseUp += OnMouseUp;
-        control.MouseMove += OnMouseMove;
-        control.MouseWheel += OnMouseWheel;
+        _control.MouseDown += OnMouseDown;
+        _control.MouseUp += OnMouseUp;
+        _control.MouseMove += OnMouseMove;
+        _control.MouseWheel += OnMouseWheel;
     }
 
     private void OnMouseDown(object? sender, System.Windows.Forms.MouseEventArgs e)
@@ -106,5 +106,14 @@ public sealed class WinFormsMouseAdapter : IMouseAdapter
     private void OnMouseWheel(object? sender, System.Windows.Forms.MouseEventArgs e)
     {
         Interlocked.Add(ref _scrollDelta, e.Delta);
+    }
+
+    /// <summary>Unsubscribes from the control's mouse events.</summary>
+    public void Dispose()
+    {
+        _control.MouseDown -= OnMouseDown;
+        _control.MouseUp -= OnMouseUp;
+        _control.MouseMove -= OnMouseMove;
+        _control.MouseWheel -= OnMouseWheel;
     }
 }

--- a/Gondwana/Drawing/Tilesheets/TilesheetFactory.cs
+++ b/Gondwana/Drawing/Tilesheets/TilesheetFactory.cs
@@ -60,12 +60,17 @@ internal static class TilesheetFactory
 
             // Region construction already applies the region default. Apply only
             // persisted frame records afterward so frame-specific values survive.
-foreach (var frame in region.Frames ?? [])
-{
-    var adjust = frame.CollisionAdjust ?? region.CollisionAdjust;
-    if (adjust != region.CollisionAdjust)
-        runtimeRegion.SetFrameCollisionAdjust(frame.XTile, frame.YTile, adjust);
-}
+            foreach (var frame in region.Frames ?? [])
+            {
+                var adjust = frame.CollisionAdjust ?? region.CollisionAdjust;
+                if (adjust != region.CollisionAdjust)
+                {
+                    runtimeRegion.SetFrameCollisionAdjust(
+                        frame.XTile,
+                        frame.YTile,
+                        adjust);
+                }
+            }
         }
 
         if (definition.Mask is not null)
@@ -138,6 +143,8 @@ foreach (var frame in region.Frames ?? [])
             ?? throw new InvalidOperationException(
                 "TilesheetDefinition must specify an image source.");
 
+        ValidateImageDefinition(image, defaultAssetsFile);
+
         if (!string.IsNullOrWhiteSpace(image.FilePath))
         {
             return new Tilesheet(
@@ -146,33 +153,64 @@ foreach (var frame in region.Frames ?? [])
                 addDefaultRegion);
         }
 
-        if (!string.IsNullOrWhiteSpace(image.AssetEntryName))
+        AssetsFile assetsFile;
+
+        if (!string.IsNullOrWhiteSpace(image.AssetsFilePath))
         {
-            AssetsFile assetsFile;
-
-            if (!string.IsNullOrWhiteSpace(image.AssetsFilePath))
-            {
-                assetsFile = LoadExistingAssetsFile(
-                    ResolvePath(image.AssetsFilePath, baseDirectory));
-            }
-            else if (defaultAssetsFile is not null)
-            {
-                assetsFile = defaultAssetsFile;
-            }
-            else
-            {
-                throw new InvalidOperationException(
-                    "TilesheetDefinition image specifies an AssetEntryName but does not specify an AssetsFilePath, and no default AssetsFile was provided.");
-            }
-
-            return new Tilesheet(
-                assetsFile,
-                image.AssetEntryName,
-                addDefaultRegion);
+            assetsFile = LoadExistingAssetsFile(
+                ResolvePath(image.AssetsFilePath, baseDirectory));
+        }
+        else
+        {
+            assetsFile = defaultAssetsFile!;
         }
 
-        throw new InvalidOperationException(
-            "TilesheetDefinition must specify either Image.FilePath or Image.AssetEntryName.");
+        var tilesheet = new Tilesheet(
+            assetsFile,
+            image.AssetEntryName!,
+            addDefaultRegion);
+
+        // The asset entry identifies the image; it is not necessarily the logical
+        // name assigned to the tilesheet by the GTS definition.
+        tilesheet.Name = definition.Name;
+
+        return tilesheet;
+    }
+
+    private static void ValidateImageDefinition(
+        TilesheetImageDefinition image,
+        AssetsFile? defaultAssetsFile)
+    {
+        var hasFilePath = !string.IsNullOrWhiteSpace(image.FilePath);
+        var hasAssetsFilePath = !string.IsNullOrWhiteSpace(image.AssetsFilePath);
+        var hasAssetEntryName = !string.IsNullOrWhiteSpace(image.AssetEntryName);
+
+        if (hasFilePath && (hasAssetsFilePath || hasAssetEntryName))
+        {
+            throw new InvalidOperationException(
+                "TilesheetDefinition image source is ambiguous. Image.FilePath cannot be combined with Image.AssetsFilePath or Image.AssetEntryName.");
+        }
+
+        if (hasAssetsFilePath && !hasAssetEntryName)
+        {
+            throw new InvalidOperationException(
+                "TilesheetDefinition image specifies an AssetsFilePath but does not specify an AssetEntryName.");
+        }
+
+        if (hasFilePath)
+            return;
+
+        if (!hasAssetEntryName)
+        {
+            throw new InvalidOperationException(
+                "TilesheetDefinition must specify either Image.FilePath or Image.AssetEntryName.");
+        }
+
+        if (!hasAssetsFilePath && defaultAssetsFile is null)
+        {
+            throw new InvalidOperationException(
+                "TilesheetDefinition image specifies an AssetEntryName but does not specify an AssetsFilePath, and no default AssetsFile was provided.");
+        }
     }
 
     private static AssetsFile LoadExistingAssetsFile(string path)

--- a/Gondwana/Engine.cs
+++ b/Gondwana/Engine.cs
@@ -893,6 +893,7 @@ public sealed class Engine : IDisposable
         Input.GamepadManager?.Update();
 
         // raise event
+        // GL thread rendering is done as part of this invocation
         AfterFrameRender?.Invoke();
 
         // raise post-cycle timer events

--- a/Gondwana/Engine.cs
+++ b/Gondwana/Engine.cs
@@ -992,9 +992,8 @@ public sealed class Engine : IDisposable
 
                 // managed cleanup...
                 Input.KeyboardEventPoller?.StopMonitoringAllKeys();
-                Input.MouseEventPoller?.StopMonitoringMouse();
-                Input.TouchEventPoller?.StopMonitoringTouch();
-                (Input.TouchEventPoller?.Adapter as IDisposable)?.Dispose();
+                MouseEventPoller.Reset();
+                TouchEventPoller.Reset();
 
                 if (Input.GamepadManager is not null)
                     foreach (var gamepadAdapter in Input.GamepadManager.ConnectedAdapters)

--- a/Gondwana/EngineInputSystems.cs
+++ b/Gondwana/EngineInputSystems.cs
@@ -83,8 +83,9 @@ public sealed class EngineInputSystems
         get => TouchEventPoller.Instance?.Adapter;
         set
         {
-            (TouchEventPoller.Instance?.Adapter as IDisposable)?.Dispose();
-            if (value != null)
+            if (value is null)
+                TouchEventPoller.Reset();
+            else
                 TouchEventPoller.Initialize(value);
         }
     }

--- a/Gondwana/Input/Mouse/MouseEventPoller.cs
+++ b/Gondwana/Input/Mouse/MouseEventPoller.cs
@@ -181,8 +181,10 @@ public sealed class MouseEventPoller : IDisposable
 
         // now decide whether to emit an event
         bool moved = (Configuration?.TrackMouseMovement ?? false) && _lastPosition != currentPos;
-        // Adapter deltas are consumable values that reset to zero after each read.
-        bool scrolled = scrollDelta != 0;
+        // Emit a scroll event only when the delta is non-zero and has changed since the last poll.
+        // This works for both adapters that reset delta to 0 after each read and adapters that
+        // hold a persistent delta until it changes, preventing repeated events on every poll.
+        bool scrolled = scrollDelta != 0 && scrollDelta != _lastScrollDelta;
         _lastScrollDelta = scrollDelta;
 
         if (anyButtonChange || moved || scrolled || isAnyButtonDown)

--- a/Gondwana/Input/Mouse/MouseEventPoller.cs
+++ b/Gondwana/Input/Mouse/MouseEventPoller.cs
@@ -9,7 +9,7 @@ namespace Gondwana.Input.Mouse;
 /// events with comprehensive information including button states, position data, scroll deltas,
 /// and keyboard modifier states, with support for event throttling and pause functionality.
 /// </summary>
-public sealed class MouseEventPoller
+public sealed class MouseEventPoller : IDisposable
 {
     /// <summary>
     /// Gets the singleton instance of the <see cref="MouseEventPoller"/> class.
@@ -35,6 +35,8 @@ public sealed class MouseEventPoller
     /// </param>
     public static void Initialize(IMouseAdapter adapter, MouseEventConfiguration? mouseEventConfiguration = null)
     {
+        ArgumentNullException.ThrowIfNull(adapter);
+
         if (mouseEventConfiguration == null)
         {
             mouseEventConfiguration = new MouseEventConfiguration(
@@ -42,7 +44,15 @@ public sealed class MouseEventPoller
                 secondsBetweenEvents: Engine.Instance.Configuration.TimeBetweenMouseEvents);
         }
 
+        Instance?.Dispose();
         Instance = new MouseEventPoller(adapter, mouseEventConfiguration);
+    }
+
+    /// <summary>Disposes and clears the current singleton instance.</summary>
+    public static void Reset()
+    {
+        Instance?.Dispose();
+        Instance = null;
     }
 
     /// <summary>
@@ -56,7 +66,8 @@ public sealed class MouseEventPoller
 
     private readonly Dictionary<MouseButton, MouseButtonState> _buttonStates = new();
     private Point _lastPosition = new(0, 0);
-    private int _lastScrollDelta = 0;
+    private int _lastScrollDelta;
+    private bool _isDisposed;
 
     /// <summary>
     /// Gets the mouse adapter currently in use, which provides access to the underlying mouse
@@ -170,7 +181,9 @@ public sealed class MouseEventPoller
 
         // now decide whether to emit an event
         bool moved = (Configuration?.TrackMouseMovement ?? false) && _lastPosition != currentPos;
-        bool scrolled = _lastScrollDelta != scrollDelta;
+        // Adapter deltas are consumable values that reset to zero after each read.
+        bool scrolled = scrollDelta != 0;
+        _lastScrollDelta = scrollDelta;
 
         if (anyButtonChange || moved || scrolled || isAnyButtonDown)
         {
@@ -184,7 +197,7 @@ public sealed class MouseEventPoller
                 tick));
 
             _lastPosition = currentPos;
-            _lastScrollDelta = scrollDelta;
+            Configuration!._lastEventTick = tick;
         }
     }
 
@@ -224,4 +237,17 @@ public sealed class MouseEventPoller
     /// or when transitioning between scenes.
     /// </summary>
     public void StopMonitoringMouse() => Configuration = null;
+
+    /// <summary>Releases the current platform adapter when it supports disposal.</summary>
+    public void Dispose()
+    {
+        if (_isDisposed) return;
+        _isDisposed = true;
+        (Adapter as IDisposable)?.Dispose();
+        Adapter = null;
+        Configuration = null;
+
+        if (ReferenceEquals(Instance, this))
+            Instance = null;
+    }
 }

--- a/Gondwana/Input/Touch/Gestures/PinchGestureRecognizer.cs
+++ b/Gondwana/Input/Touch/Gestures/PinchGestureRecognizer.cs
@@ -24,14 +24,21 @@ public sealed class PinchGestureRecognizer : IDisposable
 {
     private readonly ITouchInput _touchInput;
     private readonly Dictionary<int, Point> _activePoints = new();
+    private double _startingDistance;
     private double _lastDistance = 0;
     private bool _isDisposed;
+
+    /// <summary>Occurs when exactly two contacts establish a pinch gesture.</summary>
+    public event EventHandler<PinchedEventArgs>? PinchStarted;
 
     /// <summary>
     /// Occurs whenever the distance between two active touch contact points changes during a pinch
     /// or spread gesture. The event data includes the relative scale delta and current distance.
     /// </summary>
     public event EventHandler<PinchedEventArgs>? PinchUpdated;
+
+    /// <summary>Occurs when the current two-contact pinch ends or is interrupted.</summary>
+    public event EventHandler<PinchedEventArgs>? PinchEnded;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PinchGestureRecognizer"/> class, subscribing
@@ -54,15 +61,17 @@ public sealed class PinchGestureRecognizer : IDisposable
     private void OnTouchBegan(object? sender, TouchEventArgs e)
     {
         var prevCount = _activePoints.Count;
+
+        if (prevCount == 2)
+            Emit(PinchPhase.Ended, PinchEnded);
+
         _activePoints[e.Touch.Id] = e.Touch.Position;
         var newCount = _activePoints.Count;
 
-        // Transition into "exactly 2" — baseline the distance so the first move has a reference.
-        // Any other count change (1→3, 3→4, etc.) clears the baseline so updates pause.
         if (prevCount != 2 && newCount == 2)
-            _lastDistance = GetCurrentDistance();
+            BeginPinch();
         else if (newCount != 2)
-            _lastDistance = 0;
+            ClearBaseline();
     }
 
     private void OnTouchMoved(object? sender, TouchEventArgs e)
@@ -79,8 +88,7 @@ public sealed class PinchGestureRecognizer : IDisposable
 
             if (currentDistance > 0)
             {
-                var scaleDelta = currentDistance / _lastDistance;
-                PinchUpdated?.Invoke(this, new PinchedEventArgs(scaleDelta, currentDistance));
+                Emit(PinchPhase.Updated, PinchUpdated, currentDistance);
             }
 
             _lastDistance = currentDistance;
@@ -90,24 +98,74 @@ public sealed class PinchGestureRecognizer : IDisposable
     private void OnTouchEnded(object? sender, TouchEventArgs e)
     {
         var prevCount = _activePoints.Count;
+
+        if (_activePoints.ContainsKey(e.Touch.Id))
+            _activePoints[e.Touch.Id] = e.Touch.Position;
+
+        if (prevCount == 2)
+            Emit(PinchPhase.Ended, PinchEnded);
+
         _activePoints.Remove(e.Touch.Id);
         var newCount = _activePoints.Count;
 
-        // Transition from 3+ down to exactly 2 — re-baseline so there is no position jump.
         if (prevCount != 2 && newCount == 2)
-            _lastDistance = GetCurrentDistance();
+            BeginPinch();
         else if (newCount < 2)
-            _lastDistance = 0;
+            ClearBaseline();
+    }
+
+    private void BeginPinch()
+    {
+        _startingDistance = GetCurrentDistance();
+        _lastDistance = _startingDistance;
+        Emit(PinchPhase.Began, PinchStarted, _startingDistance);
+    }
+
+    private void ClearBaseline()
+    {
+        _startingDistance = 0;
+        _lastDistance = 0;
+    }
+
+    private void Emit(PinchPhase phase,
+                      EventHandler<PinchedEventArgs>? handler,
+                      double? currentDistance = null)
+    {
+        if (_activePoints.Count != 2)
+            return;
+
+        var pair = _activePoints.OrderBy(kvp => kvp.Key).Take(2).ToArray();
+        var a = pair[0].Value;
+        var b = pair[1].Value;
+        var distance = currentDistance ?? GetDistance(a, b);
+        var center = new PointF((a.X + b.X) / 2f, (a.Y + b.Y) / 2f);
+
+        handler?.Invoke(this, new PinchedEventArgs(phase,
+                                                   new[] { pair[0].Key, pair[1].Key },
+                                                   center,
+                                                   _startingDistance,
+                                                   _lastDistance,
+                                                   distance));
     }
 
     private double GetCurrentDistance()
     {
         using var enumerator = _activePoints.Values.GetEnumerator();
-        if (!enumerator.MoveNext()) return 0;
+        if (!enumerator.MoveNext())
+            return 0;
+        
         var a = enumerator.Current;
-        if (!enumerator.MoveNext()) return 0;
+        
+        if (!enumerator.MoveNext())
+            return 0;
+
         var b = enumerator.Current;
 
+        return GetDistance(a, b);
+    }
+
+    private static double GetDistance(Point a, Point b)
+    {
         var dx = a.X - b.X;
         var dy = a.Y - b.Y;
         return Math.Sqrt(dx * dx + dy * dy);
@@ -125,5 +183,12 @@ public sealed class PinchGestureRecognizer : IDisposable
         _touchInput.TouchBegan -= OnTouchBegan;
         _touchInput.TouchMoved -= OnTouchMoved;
         _touchInput.TouchEnded -= OnTouchEnded;
+        Reset();
+    }
+
+    internal void Reset()
+    {
+        _activePoints.Clear();
+        ClearBaseline();
     }
 }

--- a/Gondwana/Input/Touch/Gestures/PinchPhase.cs
+++ b/Gondwana/Input/Touch/Gestures/PinchPhase.cs
@@ -1,0 +1,16 @@
+namespace Gondwana.Input.Touch.Gestures;
+
+/// <summary>
+/// Identifies the lifecycle phase of a two-contact pinch gesture.
+/// </summary>
+public enum PinchPhase
+{
+    /// <summary>Exactly two contacts became active and established the pinch baseline.</summary>
+    Began,
+
+    /// <summary>The distance or focal point between the active contacts changed.</summary>
+    Updated,
+
+    /// <summary>The two-contact pinch ended or was interrupted by another contact.</summary>
+    Ended,
+}

--- a/Gondwana/Input/Touch/Gestures/PinchedEventArgs.cs
+++ b/Gondwana/Input/Touch/Gestures/PinchedEventArgs.cs
@@ -6,6 +6,21 @@ namespace Gondwana.Input.Touch.Gestures;
 /// </summary>
 public sealed class PinchedEventArgs : EventArgs
 {
+    /// <summary>Gets the lifecycle phase of this pinch event.</summary>
+    public PinchPhase Phase { get; }
+
+    /// <summary>Gets the two contact IDs participating in the gesture.</summary>
+    public IReadOnlyList<int> TouchIds { get; }
+
+    /// <summary>Gets the midpoint between the two contacts in client coordinates.</summary>
+    public System.Drawing.PointF Center { get; }
+
+    /// <summary>Gets the distance at which this pinch gesture began.</summary>
+    public double StartingDistance { get; }
+
+    /// <summary>Gets the distance reported by the preceding pinch event.</summary>
+    public double PreviousDistance { get; }
+
     /// <summary>
     /// Gets the scale factor relative to the previous pinch update.
     /// A value greater than <c>1.0</c> indicates the fingers moved apart (zoom in / expand),
@@ -20,6 +35,11 @@ public sealed class PinchedEventArgs : EventArgs
     public double CurrentDistance { get; }
 
     /// <summary>
+    /// Gets the scale relative to the beginning of the current pinch gesture.
+    /// </summary>
+    public double TotalScale { get; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="PinchedEventArgs"/> class.
     /// </summary>
     /// <param name="scaleDelta">
@@ -30,7 +50,34 @@ public sealed class PinchedEventArgs : EventArgs
     /// </param>
     public PinchedEventArgs(double scaleDelta, double currentDistance)
     {
-        ScaleDelta = scaleDelta;
+        Phase = PinchPhase.Updated;
+        TouchIds = Array.Empty<int>();
+        Center = System.Drawing.PointF.Empty;
+        StartingDistance = currentDistance;
+        PreviousDistance = scaleDelta != 0 ? currentDistance / scaleDelta : currentDistance;
         CurrentDistance = currentDistance;
+        ScaleDelta = scaleDelta;
+        TotalScale = scaleDelta;
+    }
+
+    /// <summary>
+    /// Initializes complete pinch lifecycle data.
+    /// </summary>
+    public PinchedEventArgs(
+        PinchPhase phase,
+        IReadOnlyList<int> touchIds,
+        System.Drawing.PointF center,
+        double startingDistance,
+        double previousDistance,
+        double currentDistance)
+    {
+        Phase = phase;
+        TouchIds = touchIds ?? throw new ArgumentNullException(nameof(touchIds));
+        Center = center;
+        StartingDistance = startingDistance;
+        PreviousDistance = previousDistance;
+        CurrentDistance = currentDistance;
+        ScaleDelta = previousDistance > 0 ? currentDistance / previousDistance : 1.0;
+        TotalScale = startingDistance > 0 ? currentDistance / startingDistance : 1.0;
     }
 }

--- a/Gondwana/Input/Touch/Gestures/SwipeGestureRecognizer.cs
+++ b/Gondwana/Input/Touch/Gestures/SwipeGestureRecognizer.cs
@@ -1,3 +1,4 @@
+using Gondwana.Timers;
 using System.Drawing;
 
 namespace Gondwana.Input.Touch.Gestures;
@@ -20,6 +21,8 @@ public sealed class SwipeGestureRecognizer : IDisposable
 {
     private readonly ITouchInput _touchInput;
     private readonly Dictionary<int, SwipeState> _activeSwipes = new();
+    private readonly HashSet<int> _activeContacts = new();
+    private bool _isMultiTouchSequence;
     private bool _isDisposed;
 
     /// <summary>
@@ -28,6 +31,13 @@ public sealed class SwipeGestureRecognizer : IDisposable
     /// Default is <c>200</c> pixels per second.
     /// </summary>
     public double MinimumSwipeSpeedPixelsPerSecond { get; set; } = 200;
+
+    /// <summary>
+    /// Gets or sets the minimum straight-line travel distance required for a swipe.
+    /// This prevents a short, fast tap from also being recognized as a swipe.
+    /// Default is <c>30</c> pixels.
+    /// </summary>
+    public double MinimumSwipeDistancePixels { get; set; } = 30;
 
     /// <summary>
     /// Occurs when a qualifying swipe gesture is detected.
@@ -53,11 +63,31 @@ public sealed class SwipeGestureRecognizer : IDisposable
 
     private void OnTouchBegan(object? sender, TouchEventArgs e)
     {
-        _activeSwipes[e.Touch.Id] = new SwipeState(e.Touch.Position);
+        _activeContacts.Add(e.Touch.Id);
+
+        if (_activeContacts.Count > 1)
+        {
+            _isMultiTouchSequence = true;
+            _activeSwipes.Clear();
+            return;
+        }
+
+        if (!_isMultiTouchSequence)
+            _activeSwipes[e.Touch.Id] = new SwipeState(e.Touch.Position, e.Tick);
     }
 
     private void OnTouchEnded(object? sender, TouchEventArgs e)
     {
+        _activeContacts.Remove(e.Touch.Id);
+
+        if (_isMultiTouchSequence)
+        {
+            _activeSwipes.Remove(e.Touch.Id);
+            if (_activeContacts.Count == 0)
+                _isMultiTouchSequence = false;
+            return;
+        }
+
         if (!_activeSwipes.TryGetValue(e.Touch.Id, out var state))
             return;
 
@@ -72,14 +102,14 @@ public sealed class SwipeGestureRecognizer : IDisposable
         var dy = endPos.Y - state.StartPosition.Y;
 
         var distance = Math.Sqrt(dx * dx + dy * dy);
-        var elapsed = (DateTime.UtcNow - state.StartTime).TotalSeconds;
+        var elapsed = HighResTimer.GetDuration(state.StartTick, e.Tick);
 
         if (elapsed <= 0)
             return;
 
         var speed = distance / elapsed;
 
-        if (speed < MinimumSwipeSpeedPixelsPerSecond)
+        if (!WouldRecognize(distance, elapsed))
             return;
 
         var direction = Math.Abs(dx) >= Math.Abs(dy)
@@ -100,14 +130,20 @@ public sealed class SwipeGestureRecognizer : IDisposable
 
         _touchInput.TouchBegan -= OnTouchBegan;
         _touchInput.TouchEnded -= OnTouchEnded;
+        Reset();
     }
 
-    private readonly record struct SwipeState(Point StartPosition, DateTime StartTime)
+    internal void Reset()
     {
-        /// <summary>
-        /// Initializes a new swipe tracking state starting at the specified position and the current UTC time.
-        /// </summary>
-        /// <param name="startPosition">The position where the swipe began.</param>
-        public SwipeState(Point startPosition) : this(startPosition, DateTime.UtcNow) { }
+        _activeSwipes.Clear();
+        _activeContacts.Clear();
+        _isMultiTouchSequence = false;
     }
+
+    internal bool WouldRecognize(double distance, double elapsedSeconds)
+        => elapsedSeconds > 0 &&
+           distance >= MinimumSwipeDistancePixels &&
+           distance / elapsedSeconds >= MinimumSwipeSpeedPixelsPerSecond;
+
+    private readonly record struct SwipeState(Point StartPosition, long StartTick);
 }

--- a/Gondwana/Input/Touch/Gestures/TapGestureRecognizer.cs
+++ b/Gondwana/Input/Touch/Gestures/TapGestureRecognizer.cs
@@ -29,6 +29,7 @@ public sealed class TapGestureRecognizer : IDisposable
     private readonly Dictionary<int, TapState> _activeTaps = new();
     private readonly HashSet<int> _activeContacts = new();
     private bool _isMultiTouchSequence;
+
     internal SwipeGestureRecognizer? CompetingSwipeRecognizer { get; set; }
 
     private bool _isDisposed;

--- a/Gondwana/Input/Touch/Gestures/TapGestureRecognizer.cs
+++ b/Gondwana/Input/Touch/Gestures/TapGestureRecognizer.cs
@@ -1,3 +1,4 @@
+using Gondwana.Timers;
 using System.Drawing;
 
 namespace Gondwana.Input.Touch.Gestures;
@@ -26,6 +27,9 @@ public sealed class TapGestureRecognizer : IDisposable
 
     // Per-touch tracking: key = touch ID
     private readonly Dictionary<int, TapState> _activeTaps = new();
+    private readonly HashSet<int> _activeContacts = new();
+    private bool _isMultiTouchSequence;
+    internal SwipeGestureRecognizer? CompetingSwipeRecognizer { get; set; }
 
     private bool _isDisposed;
 
@@ -68,7 +72,17 @@ public sealed class TapGestureRecognizer : IDisposable
 
     private void OnTouchBegan(object? sender, TouchEventArgs e)
     {
-        _activeTaps[e.Touch.Id] = new TapState(e.Touch.Position);
+        _activeContacts.Add(e.Touch.Id);
+
+        if (_activeContacts.Count > 1)
+        {
+            _isMultiTouchSequence = true;
+            _activeTaps.Clear();
+            return;
+        }
+
+        if (!_isMultiTouchSequence)
+            _activeTaps[e.Touch.Id] = new TapState(e.Touch.Position, e.Tick);
     }
 
     private void OnTouchMoved(object? sender, TouchEventArgs e)
@@ -89,6 +103,16 @@ public sealed class TapGestureRecognizer : IDisposable
 
     private void OnTouchEnded(object? sender, TouchEventArgs e)
     {
+        _activeContacts.Remove(e.Touch.Id);
+
+        if (_isMultiTouchSequence)
+        {
+            _activeTaps.Remove(e.Touch.Id);
+            if (_activeContacts.Count == 0)
+                _isMultiTouchSequence = false;
+            return;
+        }
+
         if (!_activeTaps.TryGetValue(e.Touch.Id, out var state))
             return;
 
@@ -98,9 +122,17 @@ public sealed class TapGestureRecognizer : IDisposable
         if (state.Cancelled || e.Touch.Phase == TouchPhase.Cancelled)
             return;
 
-        var elapsed = (DateTime.UtcNow - state.StartTime).TotalSeconds;
-        if (elapsed <= MaxTapDurationSeconds)
+        var dx = e.Touch.Position.X - state.StartPosition.X;
+        var dy = e.Touch.Position.Y - state.StartPosition.Y;
+        var distance = Math.Sqrt(dx * dx + dy * dy);
+        var elapsed = HighResTimer.GetDuration(state.StartTick, e.Tick);
+
+        if (distance <= MaxTapMovementPixels &&
+            elapsed <= MaxTapDurationSeconds &&
+            !(CompetingSwipeRecognizer?.WouldRecognize(distance, elapsed) ?? false))
+        {
             Tapped?.Invoke(this, new TappedEventArgs(e.Touch.Id, state.StartPosition));
+        }
     }
 
     /// <summary>
@@ -115,14 +147,23 @@ public sealed class TapGestureRecognizer : IDisposable
         _touchInput.TouchBegan -= OnTouchBegan;
         _touchInput.TouchMoved -= OnTouchMoved;
         _touchInput.TouchEnded -= OnTouchEnded;
+        Reset();
     }
 
-    private record struct TapState(Point StartPosition, DateTime StartTime, bool Cancelled)
+    internal void Reset()
+    {
+        _activeTaps.Clear();
+        _activeContacts.Clear();
+        _isMultiTouchSequence = false;
+    }
+
+    private record struct TapState(Point StartPosition, long StartTick, bool Cancelled)
     {
         /// <summary>
-        /// Initializes a new tap tracking state starting at the specified position and the current UTC time.
+        /// Initializes a new tap tracking state at the specified position and engine tick.
         /// </summary>
         /// <param name="startPosition">The position where the tap began.</param>
-        public TapState(Point startPosition) : this(startPosition, DateTime.UtcNow, false) { }
+        /// <param name="startTick">The monotonic engine tick at which the tap began.</param>
+        public TapState(Point startPosition, long startTick) : this(startPosition, startTick, false) { }
     }
 }

--- a/Gondwana/Input/Touch/ITouchAdapter.cs
+++ b/Gondwana/Input/Touch/ITouchAdapter.cs
@@ -9,6 +9,15 @@ namespace Gondwana.Input.Touch;
 public interface ITouchAdapter
 {
     /// <summary>
+    /// Drains and returns all touch contacts that began since the last call.
+    /// Keeping beginnings in a queue prevents a short tap that begins and ends between two
+    /// engine polls from being lost. Adapters that do not maintain a beginning queue may rely
+    /// on the default empty implementation; the poller will still discover active contacts
+    /// from <see cref="ActiveTouches"/>.
+    /// </summary>
+    IReadOnlyList<TouchPoint> ConsumeBeganTouches() => Array.Empty<TouchPoint>();
+
+    /// <summary>
     /// Gets the list of touch contact points that are currently active (in contact with the surface).
     /// This list reflects the state at the most recent platform pointer event.
     /// An empty list indicates no fingers are currently in contact.

--- a/Gondwana/Input/Touch/TouchEventConfiguration.cs
+++ b/Gondwana/Input/Touch/TouchEventConfiguration.cs
@@ -2,20 +2,20 @@ namespace Gondwana.Input.Touch;
 
 /// <summary>
 /// Represents the configuration for touch event monitoring, including timing controls for
-/// event throttling and pause functionality. This configuration is used by
-/// <see cref="TouchEventPoller"/> to control how frequently touch events are raised and
+/// movement-event throttling and pause functionality. This configuration is used by
+/// <see cref="TouchEventPoller"/> to control how frequently touch movement events are raised and
 /// whether event processing is currently paused.
 /// </summary>
 public class TouchEventConfiguration : InputEventConfigurationBase
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="TouchEventConfiguration"/> class with the
-    /// specified event timing and pause settings.
+    /// specified movement-event timing and pause settings.
     /// </summary>
     /// <param name="secondsBetweenEvents">
-    /// The minimum time interval in seconds that must elapse between consecutive touch events.
-    /// Use this to throttle high-frequency touch input. A value of 0 means no throttling is applied,
-    /// and events will be generated as frequently as the touch state changes. Default is 0.
+    /// The minimum time interval in seconds that must elapse between consecutive touch movement
+    /// events. Began, ended, and cancelled transitions are never throttled. A value of 0 means
+    /// no movement throttling is applied. Default is 0.
     /// </param>
     /// <param name="isPaused">
     /// A value indicating whether event processing for touch is initially paused.

--- a/Gondwana/Input/Touch/TouchEventPoller.cs
+++ b/Gondwana/Input/Touch/TouchEventPoller.cs
@@ -20,7 +20,7 @@ namespace Gondwana.Input.Touch;
 /// transitions, and raise events on the engine thread.
 /// </para>
 /// </remarks>
-public sealed class TouchEventPoller : ITouchInput
+public sealed class TouchEventPoller : ITouchInput, IDisposable
 {
     /// <summary>
     /// Gets the singleton instance of the <see cref="TouchEventPoller"/> class.
@@ -46,9 +46,22 @@ public sealed class TouchEventPoller : ITouchInput
     /// </param>
     public static void Initialize(ITouchAdapter adapter, TouchEventConfiguration? config = null)
     {
+        ArgumentNullException.ThrowIfNull(adapter);
+
         config ??= new TouchEventConfiguration(
             secondsBetweenEvents: Engine.Instance.Configuration.TimeBetweenTouchEvents);
+
+        Instance?.Dispose();
         Instance = new TouchEventPoller(adapter, config);
+    }
+
+    /// <summary>
+    /// Disposes and clears the current singleton instance, including its adapter.
+    /// </summary>
+    public static void Reset()
+    {
+        Instance?.Dispose();
+        Instance = null;
     }
 
     private readonly Dictionary<int, TouchPoint> _activeTouches = new();
@@ -65,7 +78,7 @@ public sealed class TouchEventPoller : ITouchInput
     public ITouchAdapter? Adapter { get; private set; }
 
     /// <summary>
-    /// Gets the current touch event configuration, which controls throttling interval and pause state.
+    /// Gets the current touch event configuration, which controls movement-event throttling and pause state.
     /// Returns <c>null</c> if touch monitoring has been stopped or not yet configured.
     /// </summary>
     public TouchEventConfiguration? Configuration { get; private set; }
@@ -113,6 +126,7 @@ public sealed class TouchEventPoller : ITouchInput
     /// Gets the pinch gesture recognizer used by this poller.
     /// </summary>
     public PinchGestureRecognizer PinchRecognizer { get; }
+    private bool _isDisposed;
 
     private TouchEventPoller(ITouchAdapter adapter, TouchEventConfiguration config)
     {
@@ -122,11 +136,17 @@ public sealed class TouchEventPoller : ITouchInput
         TapRecognizer = new TapGestureRecognizer(this);
         SwipeRecognizer = new SwipeGestureRecognizer(this);
         PinchRecognizer = new PinchGestureRecognizer(this);
+        TapRecognizer.CompetingSwipeRecognizer = SwipeRecognizer;
 
         TapRecognizer.Tapped += (_, e) => TouchEvent?.Invoke(new GestureEventArgs(e));
         SwipeRecognizer.Swiped += (_, e) => TouchEvent?.Invoke(new GestureEventArgs(e));
-        PinchRecognizer.PinchUpdated += (_, e) => TouchEvent?.Invoke(new GestureEventArgs(e));
+        PinchRecognizer.PinchStarted += OnPinch;
+        PinchRecognizer.PinchUpdated += OnPinch;
+        PinchRecognizer.PinchEnded += OnPinch;
     }
+
+    private void OnPinch(object? sender, PinchedEventArgs e)
+        => TouchEvent?.Invoke(new GestureEventArgs(e));
 
     /// <summary>
     /// Polls the touch adapter for input state changes and raises touch events when appropriate
@@ -136,19 +156,18 @@ public sealed class TouchEventPoller : ITouchInput
     /// Each call performs the following steps:
     /// <list type="number">
     /// <item><description>
-    /// Drains <see cref="ITouchAdapter.ConsumeEndedTouches"/>, fires <see cref="TouchEnded"/>
-    /// for each known contact, and removes it from tracked state. This step always runs
-    /// regardless of throttle state so gesture recognizers receive prompt phase notifications.
+    /// Drains queued beginnings and endings. Lifecycle transitions are never throttled; only
+    /// movement events are eligible for throttling.
     /// </description></item>
     /// <item><description>
-    /// When not paused and the throttle interval has elapsed: compares
-    /// <see cref="ITouchAdapter.ActiveTouches"/> against the last-known snapshot —
-    /// new IDs fire <see cref="TouchBegan"/>; same ID with a moved position fires <see cref="TouchMoved"/>.
+    /// When not paused, compares <see cref="ITouchAdapter.ActiveTouches"/> against the
+    /// last-emitted state. New IDs fire <see cref="TouchBegan"/> immediately; moved contacts
+    /// fire <see cref="TouchMoved"/> when the movement throttle interval has elapsed.
     /// </description></item>
-    /// <item><description>Updates the internal active-contact snapshot.</description></item>
     /// <item><description>
-    /// Advances the throttle timestamp only when at least one event was actually emitted,
-    /// so an idle poller never resets the throttle window.
+    /// Updates <see cref="ActiveTouches"/> from the poller's last-emitted contact state.
+    /// During movement throttling, positions therefore intentionally lag adapter state until
+    /// the next movement event is emitted.
     /// </description></item>
     /// </list>
     /// </remarks>
@@ -158,53 +177,74 @@ public sealed class TouchEventPoller : ITouchInput
     /// </param>
     internal void PollForEvents(long tick)
     {
-        if (Adapter is null) return;
+        if (_isDisposed || Adapter is null) return;
 
-        bool eventEmitted = false;
-
-        // Step 1: Always drain ended/cancelled contacts — prompt delivery is required for
-        // gesture recognizers (e.g. tap duration) regardless of throttle state.
+        var began = Adapter.ConsumeBeganTouches();
         var ended = Adapter.ConsumeEndedTouches();
+
+        // A paused/stopped poller deliberately establishes a new logical contact boundary.
+        // Drain transient queues, forget prior contacts, and begin fresh on resume.
+        if (Configuration is null || Configuration.IsPaused)
+        {
+            ClearContactState();
+            return;
+        }
+
+        // Lifecycle transitions are lossless and are never throttled.
+        foreach (var beganPoint in began)
+        {
+            if (_activeTouches.ContainsKey(beganPoint.Id))
+                continue;
+
+            var normalized = new TouchPoint(
+                beganPoint.Id,
+                beganPoint.Position,
+                TouchPhase.Began);
+
+            _activeTouches[normalized.Id] = normalized;
+            TouchBegan?.Invoke(this, new TouchEventArgs(normalized, tick));
+        }
+
         foreach (var endedPoint in ended)
         {
+            // A beginning and ending may both have occurred between engine polls. The queued
+            // beginning above ensures consumers still receive a complete lifecycle.
             if (_activeTouches.Remove(endedPoint.Id))
-            {
                 TouchEnded?.Invoke(this, new TouchEventArgs(endedPoint, tick));
-                eventEmitted = true;
+        }
+
+        var currentActive = Adapter.ActiveTouches;
+
+        // Discover active contacts for adapters that use the default empty beginning queue.
+        foreach (var point in currentActive)
+        {
+            if (!_activeTouches.ContainsKey(point.Id))
+            {
+                var normalized = new TouchPoint(point.Id, point.Position, TouchPhase.Began);
+                _activeTouches[normalized.Id] = normalized;
+                TouchBegan?.Invoke(this, new TouchEventArgs(normalized, tick));
             }
         }
 
-        // Step 2: Only emit Began/Moved events when not paused and throttle interval has elapsed.
-        if (Configuration is not null && !Configuration.IsPaused && Configuration.ReadyForNextEvent(tick))
+        bool movementEmitted = false;
+        if (Configuration.ReadyForNextEvent(tick))
         {
-            var currentActive = Adapter.ActiveTouches;
             foreach (var point in currentActive)
             {
-                if (!_activeTouches.TryGetValue(point.Id, out var known))
-                {
-                    // New contact
-                    _activeTouches[point.Id] = point;
-                    TouchBegan?.Invoke(this, new TouchEventArgs(point, tick));
-                    eventEmitted = true;
-                }
-                else if (known.Position != point.Position)
-                {
-                    // Existing contact moved. The poller owns phase semantics for transition events,
-                    // so TouchPhase.Moved is always correct here regardless of the adapter's stored phase.
-                    var movedPoint = new TouchPoint(point.Id, point.Position, TouchPhase.Moved);
-                    _activeTouches[point.Id] = movedPoint;
-                    TouchMoved?.Invoke(this, new TouchEventArgs(movedPoint, tick));
-                    eventEmitted = true;
-                }
+                if (!_activeTouches.TryGetValue(point.Id, out var known) ||
+                    known.Position == point.Position)
+                    continue;
+
+                var movedPoint = new TouchPoint(point.Id, point.Position, TouchPhase.Moved);
+                _activeTouches[point.Id] = movedPoint;
+                TouchMoved?.Invoke(this, new TouchEventArgs(movedPoint, tick));
+                movementEmitted = true;
             }
         }
 
-        // Step 3: Always update snapshot so ActiveTouches reflects current reality.
         _activeTouchesSnapshot = _activeTouches.Values.ToArray();
 
-        // Step 4: Advance the throttle timestamp only when an event was actually emitted,
-        // so an idle poller never resets the throttle window and defers real touches.
-        if (eventEmitted && Configuration is not null)
+        if (movementEmitted)
             Configuration._lastEventTick = tick;
     }
 
@@ -214,7 +254,8 @@ public sealed class TouchEventPoller : ITouchInput
     /// Call this method to begin monitoring touch input or to change monitoring settings.
     /// </summary>
     /// <param name="timeBetweenEvents">
-    /// The minimum time interval in seconds between consecutive touch events. Use the
+    /// The minimum time interval in seconds between consecutive touch movement events. Touch
+    /// beginnings, endings, and cancellations are never throttled. Use the
     /// default time between touch events from <see cref="Engine.Configuration.TimeBetweenTouchEvents"/>
     /// when a value less than zero is supplied. A value of 0 means no throttling.
     /// </param>
@@ -235,5 +276,45 @@ public sealed class TouchEventPoller : ITouchInput
     /// Stops monitoring touch input by clearing the configuration. After calling this method,
     /// touch events will no longer be raised until <see cref="StartMonitoringTouch"/> is called again.
     /// </summary>
-    public void StopMonitoringTouch() => Configuration = null;
+    public void StopMonitoringTouch()
+    {
+        Configuration = null;
+        ClearContactState();
+    }
+
+    private void ClearContactState()
+    {
+        _activeTouches.Clear();
+        _activeTouchesSnapshot = Array.Empty<TouchPoint>();
+        TapRecognizer.Reset();
+        SwipeRecognizer.Reset();
+        PinchRecognizer.Reset();
+    }
+
+    /// <summary>
+    /// Releases recognizers and the current platform adapter.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_isDisposed)
+            return;
+
+        _isDisposed = true;
+
+        TapRecognizer.Dispose();
+        SwipeRecognizer.Dispose();
+        PinchRecognizer.PinchStarted -= OnPinch;
+        PinchRecognizer.PinchUpdated -= OnPinch;
+        PinchRecognizer.PinchEnded -= OnPinch;
+        PinchRecognizer.Dispose();
+
+        (Adapter as IDisposable)?.Dispose();
+        Adapter = null;
+        Configuration = null;
+        _activeTouches.Clear();
+        _activeTouchesSnapshot = Array.Empty<TouchPoint>();
+
+        if (ReferenceEquals(Instance, this))
+            Instance = null;
+    }
 }

--- a/Gondwana/Input/Touch/TouchPhase.cs
+++ b/Gondwana/Input/Touch/TouchPhase.cs
@@ -17,6 +17,8 @@ public enum TouchPhase
 
     /// <summary>
     /// A finger or pointer is in contact with the surface but has not moved since the last event.
+    /// Gondwana currently retains this conventional phase for adapter and consumer compatibility,
+    /// but <see cref="TouchEventPoller"/> does not raise a separate stationary event.
     /// </summary>
     Stationary,
 

--- a/Gondwana/Rendering/RefreshQueue.cs
+++ b/Gondwana/Rendering/RefreshQueue.cs
@@ -7,10 +7,15 @@ namespace Gondwana.Rendering;
 
 internal sealed class RefreshQueue
 {
+    private readonly Func<bool> _isEnabled;
     private readonly List<Rectangle> _worldRects;   // World-space dirty regions (pixels)
     private readonly object _syncRoot = new();      // Guards _worldRects for cross-thread access
 
-    internal RefreshQueue() => _worldRects = new List<Rectangle>(64);
+    internal RefreshQueue(Func<bool> isEnabled)
+    {
+        _isEnabled = isEnabled ?? throw new ArgumentNullException(nameof(isEnabled));
+        _worldRects = new List<Rectangle>(64);
+    }
 
     /// <summary>
     /// True if there is at least one world-space dirty rectangle enqueued.
@@ -49,7 +54,7 @@ internal sealed class RefreshQueue
     /// </summary>
     internal void AddWorldRect(Rectangle worldPixelRange)
     {
-        if (worldPixelRange.IsEmpty)
+        if (!_isEnabled() || worldPixelRange.IsEmpty)
             return;
 
         // ensure we're on the engine thread
@@ -75,7 +80,7 @@ internal sealed class RefreshQueue
 
     internal void AddViewScreenRect(View view, SceneLayer sceneLayer, Rectangle screenPixelRange)
     {
-        if (screenPixelRange.IsEmpty)
+        if (!_isEnabled() || screenPixelRange.IsEmpty)
             return;
         
         if (view is null)

--- a/Gondwana/Rendering/RenderSurfaceHost.cs
+++ b/Gondwana/Rendering/RenderSurfaceHost.cs
@@ -236,10 +236,9 @@ public sealed class RenderSurfaceHost<TBackbuffer> : RenderSurfaceHostBase
     /// </remarks>
     public void Bind(Scene newScene, bool limitCameraToWorldBoundPx = true)
     {
-        if (newScene == null)
-            throw new ArgumentNullException(nameof(newScene), "Cannot bind to null Scene.");
+        ArgumentNullException.ThrowIfNull(newScene, "Cannot bind to null Scene.");
 
-        if (newScene == _scene)
+        if (ReferenceEquals(newScene, _scene))
             return;
 
         // Claim the new scene before releasing the old one. If another host owns it,
@@ -258,34 +257,18 @@ public sealed class RenderSurfaceHost<TBackbuffer> : RenderSurfaceHostBase
             }
 
             _scene = newScene;
-
             ViewManager.BindToScene(_scene, limitCameraToWorldBoundPx);
+
             _scene.SceneDisposing += OnSourceDisposing;
             _scene.FullRefreshNeeded = true;
         }
         catch
         {
+            // Release the failed new binding and restore the previous scene.
             newScene.UnbindRenderSurfaceHost(this);
             _scene = oldScene;
 
             if (!ReferenceEquals(oldScene, Scene.Empty))
-            {
-                oldScene.BindRenderSurfaceHost(this);
-                oldScene.SceneDisposing += OnSourceDisposing;
-            }
-
-            _scene = newScene;
-
-            ViewManager.BindToScene(_scene, limitCameraToWorldBoundPx);
-            _scene.SceneDisposing += OnSourceDisposing;
-            _scene.FullRefreshNeeded = true;
-        }
-        catch
-        {
-            newScene.UnbindRenderSurfaceHost(this);
-            _scene = oldScene;
-
-            if (oldScene != null)
             {
                 oldScene.BindRenderSurfaceHost(this);
                 oldScene.SceneDisposing += OnSourceDisposing;

--- a/Gondwana/Rendering/RenderSurfaceHost.cs
+++ b/Gondwana/Rendering/RenderSurfaceHost.cs
@@ -455,10 +455,9 @@ public sealed class RenderSurfaceHost<TBackbuffer> : RenderSurfaceHostBase
 
             try
             {
-                // 1) Force-refresh all DirectDrawings that overlay this view.
+                // 1) View overlays are drawn unconditionally by this full-frame path.
+                // They must not enqueue dirty regions that GL rendering never consumes.
                 var overlays = DirectDrawingManager.Instance.GetDrawingsForView(view);
-                foreach (var overlay in overlays)
-                    overlay.ForceRefresh();
 
                 var vp = view.Viewport.TargetRectPx;
 

--- a/Gondwana/Rendering/RenderSurfaceHost.cs
+++ b/Gondwana/Rendering/RenderSurfaceHost.cs
@@ -251,10 +251,27 @@ public sealed class RenderSurfaceHost<TBackbuffer> : RenderSurfaceHostBase
         try
         {
             // Unregister from and release the old scene.
-            if (oldScene != null)
+            if (!ReferenceEquals(oldScene, Scene.Empty))
             {
                 oldScene.SceneDisposing -= OnSourceDisposing;
                 oldScene.UnbindRenderSurfaceHost(this);
+            }
+
+            _scene = newScene;
+
+            ViewManager.BindToScene(_scene, limitCameraToWorldBoundPx);
+            _scene.SceneDisposing += OnSourceDisposing;
+            _scene.FullRefreshNeeded = true;
+        }
+        catch
+        {
+            newScene.UnbindRenderSurfaceHost(this);
+            _scene = oldScene;
+
+            if (!ReferenceEquals(oldScene, Scene.Empty))
+            {
+                oldScene.BindRenderSurfaceHost(this);
+                oldScene.SceneDisposing += OnSourceDisposing;
             }
 
             _scene = newScene;

--- a/Gondwana/Rendering/RenderSurfaceHost.cs
+++ b/Gondwana/Rendering/RenderSurfaceHost.cs
@@ -408,13 +408,47 @@ public sealed class RenderSurfaceHost<TBackbuffer> : RenderSurfaceHostBase
         InvokePostSceneCanvasHooks();
     }
 
+    /// <summary>
+    /// Dirty-region rendering path used exclusively for non-GL backbuffers
+    /// (typically <see cref="BitmapBackbuffer"/>).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This method runs on the engine thread as part of the normal
+    /// <see cref="Engine"/> foreground cycle. Unlike the full-frame GPU path, it
+    /// uses each visible <see cref="SceneLayer"/>'s <see cref="RefreshQueue"/> to
+    /// identify the world regions that have changed and redraw only the corresponding
+    /// screen regions.
+    /// </para>
+    /// <para>
+    /// When <see cref="Scene.FullRefreshNeeded"/> is set, the visible world extent
+    /// of every view is added to each layer's refresh queue. Otherwise, a clean
+    /// scene may return without performing any drawing.
+    /// </para>
+    /// <para>
+    /// For each configured view, dirty world rectangles are projected into screen
+    /// coordinates, clipped to the view's viewport, and excluded from areas occupied
+    /// by higher-Z-order views. Cleared screen regions are propagated back to
+    /// overlapping scene layers so that removing or moving foreground content does
+    /// not erase unchanged background content.
+    /// </para>
+    /// <para>
+    /// After all views have been processed, the consumed refresh queues are cleared,
+    /// <see cref="Scene.FullRefreshNeeded"/> is reset, and post-scene canvas hooks
+    /// are invoked. Presentation is performed separately by
+    /// <see cref="PresentBackbufferToAdapter"/> after this method returns.
+    /// </para>
+    /// </remarks>
+    /// <param name="tick">
+    /// The current high-resolution engine tick used to establish the
+    /// <see cref="RenderContext"/> for this frame.
+    /// </param>
     private void RenderToBackbufferBitmap(long tick)
     {
         if (ViewManager.Views.Count == 0)
         {
             Backbuffer.ClearRect(new Rectangle(0, 0, Backbuffer.Width, Backbuffer.Height));
             Scene.FullRefreshNeeded = false;
-            RenderBackbufferEnd?.Invoke();
             return;
         }
 

--- a/Gondwana/Rendering/RenderSurfaceHost.cs
+++ b/Gondwana/Rendering/RenderSurfaceHost.cs
@@ -294,115 +294,9 @@ public sealed class RenderSurfaceHost<TBackbuffer> : RenderSurfaceHostBase
         // can silently discard dirty rects that were added after the last GL frame.
         // Instead, always re-render the entire surface each GL paint callback.
         if (Backbuffer.IsGlThreadRendered)
-        {
             RenderToBackbufferGpuFull(tick);
-            RenderBackbufferEnd?.Invoke();
-            return;
-        }
-
-        if (ViewManager.Views.Count == 0)
-        {
-            Backbuffer.ClearRect(new Rectangle(0, 0, Backbuffer.Width, Backbuffer.Height));
-            Scene.FullRefreshNeeded = false;
-            RenderBackbufferEnd?.Invoke();
-            return;
-        }
-
-        // 0) If there are no visible SceneLayers, just clear and publish the full frame.
-        if (Scene.CountOfVisibleLayers == 0)
-        {
-            Backbuffer.ClearRect(new Rectangle(0, 0, Backbuffer.Width, Backbuffer.Height));
-            Scene.FullRefreshNeeded = false;
-        }
         else
-        {
-            // 1) Handle full scene refresh once (camera moved, zoom changed, etc.): clear and mark all layers as dirty.
-            //    This already clears the whole backbuffer and enqueues a full rect per layer.
-            if (Scene.FullRefreshNeeded)
-            {
-                // this will mark the Scene.IsDirty flag as true
-                EnqueueFullSceneRefresh();
-            }
-            else
-            {
-                // scene is not dirty, this frame is done...
-                if (!Scene.IsDirty)
-                {
-                    RenderBackbufferNoOp?.Invoke();
-                    return;
-                }
-            }
-        }
-
-        // 2) Render all views to Backbuffer. Draw layers back -> front (ascending Z).
-        foreach (var view in ViewManager.Views)
-        {
-            RenderContext.Push(view, tick);
-
-            try
-            {
-                // 2.1) Force-refresh all DirectDrawings that overlay this view
-                var overlays = DirectDrawingManager.Instance.GetDrawingsForView(view);
-                foreach (var overlay in overlays)
-                {
-                    overlay.ForceRefresh();
-                }
-
-                // 2.2) identify dirty SCREEN areas across all layers for this view
-                var dirtyScreenRects = CollectDirtyScreenArea(view);
-
-                // 2.3) Clip to this view's viewport
-                var vp = view.Viewport.TargetRectPx;
-
-                // clip inclusive to current viewport
-                Backbuffer.Canvas.Save();
-                Backbuffer.Canvas.ResetMatrix();
-                Backbuffer.Canvas.ClipRect(vp.ToSKRect(), SKClipOperation.Intersect, antialias: false);
-
-                // clip exclusive to higher Z-order views
-                foreach (var blocker in ViewManager.GetViewsAbove(view))
-                {
-                    var overlap = Rectangle.Intersect(vp, blocker.Viewport.TargetRectPx);
-                    if (!overlap.IsEmpty)
-                        Backbuffer.Canvas.ClipRect(overlap.ToSKRect(), SKClipOperation.Difference, antialias: false);
-                }
-
-                // 2.4) Pre-clear dirty areas on backbuffer to Backbuffer.ClearColor
-                PreclearScreenAreas(view, dirtyScreenRects);
-
-                // 2.5) Render each visible layer's dirty regions for this view
-                //      this will draw SceneLayerTiles, Sprites, and SceneLayer-based DirectDrawings
-                var sceneLayers = Scene.VisibleSceneLayers;
-
-                for (int i = 0; i < sceneLayers.Count; i++)
-                {
-                    var layer = sceneLayers[i];
-                    RenderLayerDirtyRegions(view, layer);
-                }
-
-                // 2.6) draw all View-based DirectDrawings for this view
-                for (int i = 0; i < overlays.Count; i++)
-                    overlays[i].Draw(Backbuffer, overlays[i].GetDrawLocationScreen(view));
-
-                // 2.7) Restore from viewport clip
-                Backbuffer.Canvas.Restore();
-            }
-            finally
-            {
-                RenderContext.Pop();
-            }
-        }
-
-        // 3) Clear layer queues now that we've consumed them (avoids re-drawing same tiles next frame)
-        for (int i = 0; i < Scene.CountOfVisibleLayers; i++)
-            Scene.VisibleSceneLayers[i].RefreshQueue.ClearRefreshQueue();
-
-        Scene.FullRefreshNeeded = false;
-
-        // Notify subscribers that all scene content has been drawn and the canvas is ready for
-        // post-scene effects.  Fires before RenderBackbufferEnd so subscribers still have a
-        // chance to draw into the canvas before it is presented to the adapter.
-        InvokePostSceneCanvasHooks();
+            RenderToBackbufferBitmap(tick);
 
         RenderBackbufferEnd?.Invoke();
     }
@@ -511,6 +405,113 @@ public sealed class RenderSurfaceHost<TBackbuffer> : RenderSurfaceHostBase
         // Notify subscribers that all scene content has been drawn and the canvas is ready for
         // post-scene effects.  For GPU surfaces this runs on the GL thread while GRContext is
         // current, so subscribers may safely issue Skia GPU draw calls.
+        InvokePostSceneCanvasHooks();
+    }
+
+    private void RenderToBackbufferBitmap(long tick)
+    {
+        if (ViewManager.Views.Count == 0)
+        {
+            Backbuffer.ClearRect(new Rectangle(0, 0, Backbuffer.Width, Backbuffer.Height));
+            Scene.FullRefreshNeeded = false;
+            RenderBackbufferEnd?.Invoke();
+            return;
+        }
+
+        // 0) If there are no visible SceneLayers, just clear and publish the full frame.
+        if (Scene.CountOfVisibleLayers == 0)
+        {
+            Backbuffer.ClearRect(new Rectangle(0, 0, Backbuffer.Width, Backbuffer.Height));
+            Scene.FullRefreshNeeded = false;
+        }
+        else
+        {
+            // 1) Handle full scene refresh once (camera moved, zoom changed, etc.): clear and mark all layers as dirty.
+            //    This already clears the whole backbuffer and enqueues a full rect per layer.
+            if (Scene.FullRefreshNeeded)
+            {
+                // this will mark the Scene.IsDirty flag as true
+                EnqueueFullSceneRefresh();
+            }
+            else
+            {
+                // scene is not dirty, this frame is done...
+                if (!Scene.IsDirty)
+                {
+                    RenderBackbufferNoOp?.Invoke();
+                    return;
+                }
+            }
+        }
+
+        // 2) Render all views to Backbuffer. Draw layers back -> front (ascending Z).
+        foreach (var view in ViewManager.Views)
+        {
+            RenderContext.Push(view, tick);
+
+            try
+            {
+                // 2.1) Force-refresh all DirectDrawings that overlay this view
+                var overlays = DirectDrawingManager.Instance.GetDrawingsForView(view);
+                foreach (var overlay in overlays)
+                {
+                    overlay.ForceRefresh();
+                }
+
+                // 2.2) identify dirty SCREEN areas across all layers for this view
+                var dirtyScreenRects = CollectDirtyScreenArea(view);
+
+                // 2.3) Clip to this view's viewport
+                var vp = view.Viewport.TargetRectPx;
+
+                // clip inclusive to current viewport
+                Backbuffer.Canvas.Save();
+                Backbuffer.Canvas.ResetMatrix();
+                Backbuffer.Canvas.ClipRect(vp.ToSKRect(), SKClipOperation.Intersect, antialias: false);
+
+                // clip exclusive to higher Z-order views
+                foreach (var blocker in ViewManager.GetViewsAbove(view))
+                {
+                    var overlap = Rectangle.Intersect(vp, blocker.Viewport.TargetRectPx);
+                    if (!overlap.IsEmpty)
+                        Backbuffer.Canvas.ClipRect(overlap.ToSKRect(), SKClipOperation.Difference, antialias: false);
+                }
+
+                // 2.4) Pre-clear dirty areas on backbuffer to Backbuffer.ClearColor
+                PreclearScreenAreas(view, dirtyScreenRects);
+
+                // 2.5) Render each visible layer's dirty regions for this view
+                //      this will draw SceneLayerTiles, Sprites, and SceneLayer-based DirectDrawings
+                var sceneLayers = Scene.VisibleSceneLayers;
+
+                for (int i = 0; i < sceneLayers.Count; i++)
+                {
+                    var layer = sceneLayers[i];
+                    RenderLayerDirtyRegions(view, layer);
+                }
+
+                // 2.6) draw all View-based DirectDrawings for this view
+                for (int i = 0; i < overlays.Count; i++)
+                    overlays[i].Draw(Backbuffer, overlays[i].GetDrawLocationScreen(view));
+
+                // 2.7) Restore from viewport clip
+                Backbuffer.Canvas.Restore();
+            }
+            finally
+            {
+                RenderContext.Pop();
+            }
+        }
+
+        // 3) Clear layer queues now that we've consumed them (avoids re-drawing same tiles next frame)
+        for (int i = 0; i < Scene.CountOfVisibleLayers; i++)
+            Scene.VisibleSceneLayers[i].RefreshQueue.ClearRefreshQueue();
+
+        Scene.FullRefreshNeeded = false;
+
+        // Notify subscribers that all scene content has been drawn and the canvas is ready for
+        // post-scene effects.  Fires before RenderBackbufferEnd so subscribers still have a
+        // chance to draw into the canvas before it is presented to the adapter.
         InvokePostSceneCanvasHooks();
     }
 

--- a/Gondwana/Rendering/RenderSurfaceHost.cs
+++ b/Gondwana/Rendering/RenderSurfaceHost.cs
@@ -274,23 +274,6 @@ public sealed class RenderSurfaceHost<TBackbuffer> : RenderSurfaceHostBase
                 oldScene.SceneDisposing += OnSourceDisposing;
             }
 
-            _scene = newScene;
-
-            ViewManager.BindToScene(_scene, limitCameraToWorldBoundPx);
-            _scene.SceneDisposing += OnSourceDisposing;
-            _scene.FullRefreshNeeded = true;
-        }
-        catch
-        {
-            newScene.UnbindRenderSurfaceHost(this);
-            _scene = oldScene;
-
-            if (oldScene != null)
-            {
-                oldScene.BindRenderSurfaceHost(this);
-                oldScene.SceneDisposing += OnSourceDisposing;
-            }
-
             throw;
         }
 

--- a/Gondwana/Rendering/RenderSurfaceHost.cs
+++ b/Gondwana/Rendering/RenderSurfaceHost.cs
@@ -695,39 +695,11 @@ public sealed class RenderSurfaceHost<TBackbuffer> : RenderSurfaceHostBase
 
     private bool _disposed;
 
-    /// <summary>
-    /// Releases all resources used by this <see cref="RenderSurfaceHost{TBackbuffer}"/> instance.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// This method releases managed resources including the backbuffer and releases its scene binding.
-    /// </para>
-    /// <para>
-    /// After calling <see cref="Dispose()"/>, this instance should not be used. Calling
-    /// <see cref="Dispose()"/> multiple times is safe and has no additional effect.
-    /// </para>
-    /// </remarks>
-    public void Dispose()
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
     {
-        Dispose(true);
-    }
-
-    /// <summary>
-    /// Releases resources used by this <see cref="RenderSurfaceHost{TBackbuffer}"/> instance.
-    /// </summary>
-    /// <param name="disposing">
-    /// <see langword="true"/> to release both managed and unmanaged resources;
-    /// <see langword="false"/> to release only unmanaged resources (called from finalizer).
-    /// </param>
-    /// <remarks>
-    /// When <paramref name="disposing"/> is <see langword="true"/>, this method releases the backbuffer
-    /// and clears the reference. Derived classes should override this method to release additional resources.
-    /// </remarks>
-    public void Dispose(bool disposing)
-    {
-        if (_disposed) return;
-
-        base.Dispose(disposing);
+        if (_disposed)
+            return;
 
         if (disposing)
         {
@@ -742,9 +714,9 @@ public sealed class RenderSurfaceHost<TBackbuffer> : RenderSurfaceHostBase
         }
 
         _disposed = true;
-    }
 
-    ~RenderSurfaceHost() => Dispose(false);
+        base.Dispose(disposing);
+    }
 
     #endregion IDisposable
 

--- a/Gondwana/Rendering/RenderSurfaceHost.cs
+++ b/Gondwana/Rendering/RenderSurfaceHost.cs
@@ -220,6 +220,9 @@ public sealed class RenderSurfaceHost<TBackbuffer> : RenderSurfaceHostBase
     /// <see langword="false"/> to allow cameras to move freely beyond the scene boundaries.
     /// </param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="newScene"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <paramref name="newScene"/> is already bound to a different render surface host.
+    /// </exception>
     /// <remarks>
     /// <para>
     /// Binding a scene unregisters event handlers from the previous scene (if any), registers handlers
@@ -239,18 +242,40 @@ public sealed class RenderSurfaceHost<TBackbuffer> : RenderSurfaceHostBase
         if (newScene == _scene)
             return;
 
-        // Unregister from the old scene (if any)
-        if (_scene != null)
-        {
-            _scene.SceneDisposing -= OnSourceDisposing;
-        }
+        // Claim the new scene before releasing the old one. If another host owns it,
+        // Bind fails without disturbing this host's current scene.
+        newScene.BindRenderSurfaceHost(this);
 
         var oldScene = _scene;
-        _scene = newScene;
 
-        ViewManager.BindToScene(_scene, limitCameraToWorldBoundPx);
-        _scene.SceneDisposing += OnSourceDisposing;
-        _scene.FullRefreshNeeded = true;
+        try
+        {
+            // Unregister from and release the old scene.
+            if (oldScene != null)
+            {
+                oldScene.SceneDisposing -= OnSourceDisposing;
+                oldScene.UnbindRenderSurfaceHost(this);
+            }
+
+            _scene = newScene;
+
+            ViewManager.BindToScene(_scene, limitCameraToWorldBoundPx);
+            _scene.SceneDisposing += OnSourceDisposing;
+            _scene.FullRefreshNeeded = true;
+        }
+        catch
+        {
+            newScene.UnbindRenderSurfaceHost(this);
+            _scene = oldScene;
+
+            if (oldScene != null)
+            {
+                oldScene.BindRenderSurfaceHost(this);
+                oldScene.SceneDisposing += OnSourceDisposing;
+            }
+
+            throw;
+        }
 
         BindToScene?.Invoke(this, new RenderSurfaceHostBindEventArgs(oldScene, _scene));
     }
@@ -641,8 +666,7 @@ public sealed class RenderSurfaceHost<TBackbuffer> : RenderSurfaceHostBase
     /// </summary>
     /// <remarks>
     /// <para>
-    /// This method releases managed resources including the backbuffer. It does not unregister
-    /// from the scene; that should be handled by the scene's disposal logic.
+    /// This method releases managed resources including the backbuffer and releases its scene binding.
     /// </para>
     /// <para>
     /// After calling <see cref="Dispose()"/>, this instance should not be used. Calling
@@ -673,6 +697,13 @@ public sealed class RenderSurfaceHost<TBackbuffer> : RenderSurfaceHostBase
 
         if (disposing)
         {
+            if (_scene != null)
+            {
+                _scene.SceneDisposing -= OnSourceDisposing;
+                _scene.UnbindRenderSurfaceHost(this);
+                _scene = Scene.Empty;
+            }
+
             _backbuffer = null;
         }
 
@@ -687,7 +718,9 @@ public sealed class RenderSurfaceHost<TBackbuffer> : RenderSurfaceHostBase
 
     private void OnSourceDisposing(Scene scene)
     {
-        _scene = null;
+        scene.SceneDisposing -= OnSourceDisposing;
+        scene.UnbindRenderSurfaceHost(this);
+        _scene = Scene.Empty;
     }
 
     private void OnRenderSurfaceAdapterResized(RenderSurfaceAdapterResizedEventArgs args)

--- a/Gondwana/Rendering/RenderSurfaceHostBase.cs
+++ b/Gondwana/Rendering/RenderSurfaceHostBase.cs
@@ -1,6 +1,7 @@
 ﻿using Gondwana.Rendering.Backbuffers;
 using Gondwana.Rendering.Views;
 using Gondwana.Scenes;
+using Gondwana.Timers;
 using SkiaSharp;
 
 namespace Gondwana.Rendering;
@@ -88,7 +89,7 @@ public abstract class RenderSurfaceHostBase : IDisposable
         if (!Backbuffer.IsGlThreadRendered)
             return null;
 
-        var tick = Gondwana.Timers.HighResTimer.GetCurrentTick();
+        var tick = HighResTimer.GetCurrentTick();
 
         RenderToBackbuffer(tick);
         Backbuffer.EndFrame();

--- a/Gondwana/Scenes/Scene.cs
+++ b/Gondwana/Scenes/Scene.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.Drawing;
 using Gondwana.Drawing.Coordinates;
 using Gondwana.Physics.Collisions;
+using Gondwana.Rendering;
 using Newtonsoft.Json;
 
 namespace Gondwana.Scenes;
@@ -32,6 +33,12 @@ public class Scene : IEnumerable<SceneLayer>, IDisposable
 {
     [JsonProperty]
     private readonly List<SceneLayer> _sceneLayers = [];
+
+    [JsonIgnore]
+    private readonly object _renderSurfaceHostSync = new();
+
+    [JsonIgnore]
+    private RenderSurfaceHostBase? _boundRenderSurfaceHost;
     
     #region Scene events
 
@@ -168,6 +175,23 @@ public class Scene : IEnumerable<SceneLayer>, IDisposable
     public int Count => _sceneLayers?.Count ?? 0;
 
     /// <summary>
+    /// Gets the render surface host currently bound to this scene.
+    /// </summary>
+    /// <remarks>
+    /// A scene may be actively bound to at most one render surface host. Multiple camera
+    /// perspectives into the same scene should be represented by multiple views on that host.
+    /// </remarks>
+    [JsonIgnore]
+    internal RenderSurfaceHostBase? BoundRenderSurfaceHost
+    {
+        get
+        {
+            lock (_renderSurfaceHostSync)
+                return _boundRenderSurfaceHost;
+        }
+    }
+
+    /// <summary>
     /// Gets or sets a value indicating whether the entire scene needs to be refreshed on the next render.
     /// </summary>
     /// <value>
@@ -267,6 +291,52 @@ public class Scene : IEnumerable<SceneLayer>, IDisposable
     #endregion public properties
 
     #region internal properties and methods
+
+    /// <summary>
+    /// Claims this scene for the specified render surface host.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the scene is already bound to a different host.
+    /// </exception>
+    internal void BindRenderSurfaceHost(RenderSurfaceHostBase host)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+
+        // Scene.Empty is a shared null-object placeholder and is never treated as an
+        // actively rendered scene for binding ownership purposes.
+        if (ReferenceEquals(this, Empty))
+            return;
+
+        lock (_renderSurfaceHostSync)
+        {
+            if (_boundRenderSurfaceHost is not null &&
+                !ReferenceEquals(_boundRenderSurfaceHost, host))
+            {
+                throw new InvalidOperationException(
+                    $"Scene '{ID}' is already bound to another RenderSurfaceHost.");
+            }
+
+            _boundRenderSurfaceHost = host;
+        }
+    }
+
+    /// <summary>
+    /// Releases this scene when it is currently owned by the specified host.
+    /// Calls from any other host are ignored.
+    /// </summary>
+    internal void UnbindRenderSurfaceHost(RenderSurfaceHostBase host)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+
+        if (ReferenceEquals(this, Empty))
+            return;
+
+        lock (_renderSurfaceHostSync)
+        {
+            if (ReferenceEquals(_boundRenderSurfaceHost, host))
+                _boundRenderSurfaceHost = null;
+        }
+    }
 
     /// <summary>
     /// Gets a value indicating whether any visible layer in this scene has pending updates

--- a/Gondwana/Scenes/Scene.cs
+++ b/Gondwana/Scenes/Scene.cs
@@ -192,6 +192,13 @@ public class Scene : IEnumerable<SceneLayer>, IDisposable
     }
 
     /// <summary>
+    /// Gets whether the scene's current host consumes dirty-region refresh queues.
+    /// Unbound scenes retain invalidations for a future bitmap host.
+    /// </summary>
+    [JsonIgnore]
+    internal bool UsesDirtyRegionRendering => BoundRenderSurfaceHost?.Backbuffer.IsGlThreadRendered != true;
+
+    /// <summary>
     /// Gets or sets a value indicating whether the entire scene needs to be refreshed on the next render.
     /// </summary>
     /// <value>
@@ -317,6 +324,15 @@ public class Scene : IEnumerable<SceneLayer>, IDisposable
             }
 
             _boundRenderSurfaceHost = host;
+        }
+
+        // A GPU host redraws the full frame and never consumes RefreshQueue. Remove
+        // anything accumulated before binding; future additions are rejected by the
+        // queue's scene-policy callback.
+        if (!UsesDirtyRegionRendering)
+        {
+            foreach (var layer in _sceneLayers)
+                layer.RefreshQueue.ClearRefreshQueue();
         }
     }
 

--- a/Gondwana/Scenes/SceneLayer.cs
+++ b/Gondwana/Scenes/SceneLayer.cs
@@ -761,7 +761,9 @@ public class SceneLayer : IEnumerable<SceneLayerTile>, IDisposable
         // let each SceneLayerTile in array know its position in the array
         SaveGridCoordinatesToSceneLayerTiles();
         BuildTileColliders();
-        RefreshQueue = new RefreshQueue();
+        // Unbound scenes retain dirty regions for a future bitmap host. Once bound,
+        // the scene policy disables queue writes for full-frame GL rendering.
+        RefreshQueue = new RefreshQueue(() => Scene?.UsesDirtyRegionRendering ?? true);
     }
 
     private void SaveGridCoordinatesToSceneLayerTiles()

--- a/Testing/Gondwana.Tests/GpuRefreshQueueTests.cs
+++ b/Testing/Gondwana.Tests/GpuRefreshQueueTests.cs
@@ -1,0 +1,116 @@
+using System.Drawing;
+using Gondwana.Rendering;
+using Gondwana.Rendering.Backbuffers;
+using Gondwana.Scenes;
+using SkiaSharp;
+
+namespace Gondwana.Tests;
+
+[CollectionDefinition("GPU refresh queue", DisableParallelization = true)]
+public sealed class GpuRefreshQueueCollection
+{
+    public const string Name = "GPU refresh queue";
+}
+
+/// <summary>
+/// Verifies that full-frame GL rendering neither retains nor accepts dirty regions,
+/// while bitmap rendering continues to use RefreshQueue normally.
+/// </summary>
+[Collection(GpuRefreshQueueCollection.Name)]
+public sealed class GpuRefreshQueueTests
+{
+    public GpuRefreshQueueTests()
+    {
+        Engine.Instance.EngineDispatcher.BindToCurrentThread();
+        Engine.Instance.EngineDispatcher.Drain();
+    }
+
+    [Fact]
+    public void BindGpuHost_ClearsPreBindQueueAndRejectsFutureWorldRects()
+    {
+        using var scene = new Scene();
+        var layer = scene.AddLayer(4, 4);
+        var initialRect = new Rectangle(0, 0, 16, 16);
+        layer.RefreshQueue.AddWorldRect(initialRect);
+        Assert.True(layer.RefreshQueue.IsDirty);
+
+        using var host = CreateGpuHost();
+        host.Bind(scene);
+
+        Assert.False(scene.UsesDirtyRegionRendering);
+        Assert.False(layer.RefreshQueue.IsDirty);
+
+        layer.RefreshQueue.AddWorldRect(new Rectangle(16, 0, 16, 16));
+
+        Assert.False(layer.RefreshQueue.IsDirty);
+    }
+
+    [Fact]
+    public void DisabledQueue_RejectsViewRectBeforeDoingViewConversion()
+    {
+        using var scene = new Scene();
+        var layer = scene.AddLayer(4, 4);
+        using var host = CreateGpuHost();
+        host.Bind(scene);
+
+        var exception = Record.Exception(
+            () => layer.RefreshQueue.AddViewScreenRect(
+                null!,
+                null!,
+                new Rectangle(0, 0, 16, 16)));
+
+        Assert.Null(exception);
+        Assert.False(layer.RefreshQueue.IsDirty);
+    }
+
+    [Fact]
+    public void BindBitmapHost_ContinuesAcceptingDirtyRegions()
+    {
+        using var scene = new Scene();
+        var layer = scene.AddLayer(4, 4);
+        using var host = CreateBitmapHost();
+        host.Bind(scene);
+
+        layer.RefreshQueue.AddWorldRect(new Rectangle(0, 0, 16, 16));
+
+        Assert.True(scene.UsesDirtyRegionRendering);
+        Assert.True(layer.RefreshQueue.IsDirty);
+    }
+
+    [Fact]
+    public void RebindFromGpuToBitmap_ReenablesDirtyRegionTracking()
+    {
+        using var scene = new Scene();
+        var layer = scene.AddLayer(4, 4);
+
+        using (var gpuHost = CreateGpuHost())
+        {
+            gpuHost.Bind(scene);
+            layer.RefreshQueue.AddWorldRect(new Rectangle(0, 0, 16, 16));
+            Assert.False(layer.RefreshQueue.IsDirty);
+        }
+
+        using var bitmapHost = CreateBitmapHost();
+        bitmapHost.Bind(scene);
+        layer.RefreshQueue.AddWorldRect(new Rectangle(16, 0, 16, 16));
+
+        Assert.True(layer.RefreshQueue.IsDirty);
+    }
+
+    private static RenderSurfaceHost<GpuBackbuffer> CreateGpuHost() =>
+        new(new TestAdapter(320, 200));
+
+    private static RenderSurfaceHost<BitmapBackbuffer> CreateBitmapHost() =>
+        new(new TestAdapter(320, 200));
+
+    private sealed class TestAdapter(int width, int height)
+        : RenderSurfaceAdapterBase(width, height)
+    {
+        public override void Present(
+            SKImage bufferImage,
+            SKRectI bufferRect,
+            SKRect destRect)
+        {
+        }
+    }
+}

--- a/Testing/Gondwana.Tests/Input/MouseInputTests.cs
+++ b/Testing/Gondwana.Tests/Input/MouseInputTests.cs
@@ -1,0 +1,74 @@
+using System.Drawing;
+using Gondwana.Input.Keyboard;
+using Gondwana.Input.Mouse;
+
+namespace Gondwana.Tests.Input;
+
+[Collection(InputPollerCollection.Name)]
+public sealed class MouseInputTests : IDisposable
+{
+    [Fact]
+    public void Poller_DoesNotEmitPhantomZeroScrollAfterRealScroll()
+    {
+        var adapter = new FakeMouseAdapter();
+        MouseEventPoller.Initialize(
+            adapter,
+            new MouseEventConfiguration(trackMouseMovement: false));
+        var deltas = new List<int>();
+        MouseEventPoller.Instance!.MouseEvent += e => deltas.Add(e.ScrollDelta);
+
+        adapter.ScrollDelta = 120;
+        MouseEventPoller.Instance.PollForEvents(100);
+        adapter.ScrollDelta = 0;
+        MouseEventPoller.Instance.PollForEvents(101);
+
+        Assert.Equal([120], deltas);
+    }
+
+    [Fact]
+    public void Poller_AdvancesThrottleTimestampAfterEvent()
+    {
+        var adapter = new FakeMouseAdapter();
+        MouseEventPoller.Initialize(
+            adapter,
+            new MouseEventConfiguration(
+                trackMouseMovement: true,
+                secondsBetweenEvents: 1));
+        var events = 0;
+        MouseEventPoller.Instance!.MouseEvent += _ => events++;
+        var start = HighResTimer.TicksPerSecond;
+
+        adapter.CurrentPosition = new Point(1, 0);
+        MouseEventPoller.Instance.PollForEvents(start);
+        adapter.CurrentPosition = new Point(2, 0);
+        MouseEventPoller.Instance.PollForEvents(start + 1);
+
+        Assert.Equal(1, events);
+    }
+
+    [Fact]
+    public void Reset_DisposesAdapterAndClearsSingleton()
+    {
+        var adapter = new FakeMouseAdapter();
+        MouseEventPoller.Initialize(
+            adapter,
+            new MouseEventConfiguration(trackMouseMovement: true));
+
+        MouseEventPoller.Reset();
+
+        Assert.True(adapter.IsDisposed);
+        Assert.Null(MouseEventPoller.Instance);
+    }
+
+    public void Dispose() => MouseEventPoller.Reset();
+
+    private sealed class FakeMouseAdapter : IMouseAdapter, IDisposable
+    {
+        public Point CurrentPosition { get; set; }
+        public HashSet<MouseButton> PressedButtons { get; } = [];
+        public KeyboardModifierState CurrentKeyboardModifiers => KeyboardModifierState.None;
+        public int ScrollDelta { get; set; }
+        public bool IsDisposed { get; private set; }
+        public void Dispose() => IsDisposed = true;
+    }
+}

--- a/Testing/Gondwana.Tests/Input/MouseInputTests.cs
+++ b/Testing/Gondwana.Tests/Input/MouseInputTests.cs
@@ -1,6 +1,7 @@
 using System.Drawing;
 using Gondwana.Input.Keyboard;
 using Gondwana.Input.Mouse;
+using Gondwana.Timers;
 
 namespace Gondwana.Tests.Input;
 

--- a/Testing/Gondwana.Tests/Input/TouchInputTests.cs
+++ b/Testing/Gondwana.Tests/Input/TouchInputTests.cs
@@ -1,0 +1,281 @@
+using System.Drawing;
+using Gondwana.Input.Touch;
+using Gondwana.Input.Touch.Gestures;
+
+namespace Gondwana.Tests.Input;
+
+[CollectionDefinition("Input poller singleton", DisableParallelization = true)]
+public sealed class InputPollerCollection
+{
+    public const string Name = "Input poller singleton";
+}
+
+[Collection(InputPollerCollection.Name)]
+public sealed class TouchInputTests : IDisposable
+{
+    [Fact]
+    public void Poller_PreservesContactThatBeginsAndEndsBetweenPolls()
+    {
+        var adapter = new FakeTouchAdapter();
+        TouchEventPoller.Initialize(adapter, new TouchEventConfiguration());
+        var poller = TouchEventPoller.Instance!;
+        var phases = new List<TouchPhase>();
+        poller.TouchBegan += (_, e) => phases.Add(e.Touch.Phase);
+        poller.TouchEnded += (_, e) => phases.Add(e.Touch.Phase);
+
+        adapter.Begin(1, new Point(10, 20));
+        adapter.End(1, new Point(10, 20));
+        poller.PollForEvents(100);
+
+        Assert.Equal([TouchPhase.Began, TouchPhase.Ended], phases);
+        Assert.Empty(poller.ActiveTouches);
+    }
+
+    [Fact]
+    public void Poller_ThrottlesOnlyMovement()
+    {
+        var adapter = new FakeTouchAdapter();
+        TouchEventPoller.Initialize(adapter, new TouchEventConfiguration(secondsBetweenEvents: 1));
+        var poller = TouchEventPoller.Instance!;
+        var began = 0;
+        var moved = 0;
+        var ended = 0;
+        poller.TouchBegan += (_, _) => began++;
+        poller.TouchMoved += (_, _) => moved++;
+        poller.TouchEnded += (_, _) => ended++;
+
+        adapter.Begin(1, Point.Empty);
+        poller.PollForEvents(1);
+        adapter.Move(1, new Point(20, 0));
+        poller.PollForEvents(2);
+        adapter.End(1, new Point(20, 0));
+        poller.PollForEvents(3);
+
+        Assert.Equal(1, began);
+        Assert.Equal(0, moved);
+        Assert.Equal(1, ended);
+    }
+
+    [Fact]
+    public void Poller_PauseSuppressesEventsAndResumeStartsFreshContact()
+    {
+        var adapter = new FakeTouchAdapter();
+        var config = new TouchEventConfiguration(isPaused: true);
+        TouchEventPoller.Initialize(adapter, config);
+        var poller = TouchEventPoller.Instance!;
+        var began = 0;
+        poller.TouchBegan += (_, _) => began++;
+
+        adapter.Begin(1, Point.Empty);
+        poller.PollForEvents(1);
+        Assert.Equal(0, began);
+
+        config.IsPaused = false;
+        poller.PollForEvents(2);
+
+        Assert.Equal(1, began);
+    }
+
+    [Fact]
+    public void Poller_NormalizesDiscoveredContactToBeganPhase()
+    {
+        var adapter = new SnapshotOnlyTouchAdapter(
+            new TouchPoint(7, new Point(5, 6), TouchPhase.Moved));
+        TouchEventPoller.Initialize(adapter, new TouchEventConfiguration());
+        TouchPhase? phase = null;
+        TouchEventPoller.Instance!.TouchBegan += (_, e) => phase = e.Touch.Phase;
+
+        TouchEventPoller.Instance.PollForEvents(1);
+
+        Assert.Equal(TouchPhase.Began, phase);
+    }
+
+    [Fact]
+    public void ShortFastContact_IsTapButNotSwipe()
+    {
+        var input = new FakeTouchInput();
+        using var tap = new TapGestureRecognizer(input);
+        using var swipe = new SwipeGestureRecognizer(input);
+        var taps = 0;
+        var swipes = 0;
+        tap.Tapped += (_, _) => taps++;
+        swipe.Swiped += (_, _) => swipes++;
+        var start = 100L;
+        var end = start + Math.Max(1, HighResTimer.TicksPerSecond / 100);
+
+        input.Begin(1, Point.Empty, start);
+        input.End(1, new Point(10, 0), end);
+
+        Assert.Equal(1, taps);
+        Assert.Equal(0, swipes);
+    }
+
+    [Fact]
+    public void Poller_ArbitratesOverlappingTapAndSwipeThresholdsInFavorOfSwipe()
+    {
+        var adapter = new FakeTouchAdapter();
+        TouchEventPoller.Initialize(adapter, new TouchEventConfiguration());
+        var poller = TouchEventPoller.Instance!;
+        poller.TapRecognizer.MaxTapMovementPixels = 40;
+        poller.SwipeRecognizer.MinimumSwipeDistancePixels = 10;
+        poller.SwipeRecognizer.MinimumSwipeSpeedPixelsPerSecond = 100;
+        var taps = 0;
+        var swipes = 0;
+        poller.TapRecognizer.Tapped += (_, _) => taps++;
+        poller.SwipeRecognizer.Swiped += (_, _) => swipes++;
+        var start = HighResTimer.TicksPerSecond;
+
+        adapter.Begin(1, Point.Empty);
+        poller.PollForEvents(start);
+        adapter.End(1, new Point(20, 0));
+        poller.PollForEvents(start + HighResTimer.TicksPerSecond / 10);
+
+        Assert.Equal(0, taps);
+        Assert.Equal(1, swipes);
+    }
+
+    [Fact]
+    public void Tap_UsesFinalPositionEvenWithoutMovementEvent()
+    {
+        var input = new FakeTouchInput();
+        using var tap = new TapGestureRecognizer(input);
+        var taps = 0;
+        tap.Tapped += (_, _) => taps++;
+
+        input.Begin(1, Point.Empty, 100);
+        input.End(1, new Point(100, 0), 101);
+
+        Assert.Equal(0, taps);
+    }
+
+    [Fact]
+    public void MultiTouch_CancelsTapAndSwipeCandidates()
+    {
+        var input = new FakeTouchInput();
+        using var tap = new TapGestureRecognizer(input);
+        using var swipe = new SwipeGestureRecognizer(input);
+        var gestures = 0;
+        tap.Tapped += (_, _) => gestures++;
+        swipe.Swiped += (_, _) => gestures++;
+
+        input.Begin(1, Point.Empty, 100);
+        input.Begin(2, new Point(10, 0), 101);
+        input.End(1, new Point(100, 0), 102);
+        input.End(2, new Point(110, 0), 103);
+
+        Assert.Equal(0, gestures);
+    }
+
+    [Fact]
+    public void Pinch_ReportsLifecycleCenterIdsAndScale()
+    {
+        var input = new FakeTouchInput();
+        using var pinch = new PinchGestureRecognizer(input);
+        var events = new List<PinchedEventArgs>();
+        pinch.PinchStarted += (_, e) => events.Add(e);
+        pinch.PinchUpdated += (_, e) => events.Add(e);
+        pinch.PinchEnded += (_, e) => events.Add(e);
+
+        input.Begin(2, new Point(0, 0), 100);
+        input.Begin(5, new Point(10, 0), 101);
+        input.Move(5, new Point(20, 0), 102);
+        input.End(5, new Point(20, 0), 103);
+
+        Assert.Equal(
+            [PinchPhase.Began, PinchPhase.Updated, PinchPhase.Ended],
+            events.Select(e => e.Phase));
+        Assert.Equal([2, 5], events[1].TouchIds);
+        Assert.Equal(new PointF(5, 0), events[0].Center);
+        Assert.Equal(new PointF(10, 0), events[1].Center);
+        Assert.Equal(2.0, events[1].ScaleDelta, 6);
+        Assert.Equal(2.0, events[1].TotalScale, 6);
+    }
+
+    [Fact]
+    public void Reset_DisposesAdapterAndClearsSingleton()
+    {
+        var adapter = new FakeTouchAdapter();
+        TouchEventPoller.Initialize(adapter, new TouchEventConfiguration());
+
+        TouchEventPoller.Reset();
+
+        Assert.True(adapter.IsDisposed);
+        Assert.Null(TouchEventPoller.Instance);
+    }
+
+    public void Dispose() => TouchEventPoller.Reset();
+
+    private sealed class FakeTouchAdapter : ITouchAdapter, IDisposable
+    {
+        private readonly Dictionary<int, TouchPoint> _active = new();
+        private readonly Queue<TouchPoint> _began = new();
+        private readonly Queue<TouchPoint> _ended = new();
+
+        public IReadOnlyList<TouchPoint> ActiveTouches => _active.Values.ToArray();
+        public bool IsDisposed { get; private set; }
+
+        public void Begin(int id, Point position)
+        {
+            var point = new TouchPoint(id, position, TouchPhase.Began);
+            _active[id] = point;
+            _began.Enqueue(point);
+        }
+
+        public void Move(int id, Point position)
+            => _active[id] = new TouchPoint(id, position, TouchPhase.Moved);
+
+        public void End(int id, Point position)
+        {
+            _active.Remove(id);
+            _ended.Enqueue(new TouchPoint(id, position, TouchPhase.Ended));
+        }
+
+        public IReadOnlyList<TouchPoint> ConsumeBeganTouches() => Drain(_began);
+        public IReadOnlyList<TouchPoint> ConsumeEndedTouches() => Drain(_ended);
+        public void Dispose() => IsDisposed = true;
+
+        private static IReadOnlyList<TouchPoint> Drain(Queue<TouchPoint> queue)
+        {
+            var result = queue.ToArray();
+            queue.Clear();
+            return result;
+        }
+    }
+
+    private sealed class SnapshotOnlyTouchAdapter(params TouchPoint[] points) : ITouchAdapter
+    {
+        public IReadOnlyList<TouchPoint> ActiveTouches { get; } = points;
+        public IReadOnlyList<TouchPoint> ConsumeEndedTouches() => Array.Empty<TouchPoint>();
+    }
+
+    private sealed class FakeTouchInput : ITouchInput
+    {
+        private readonly Dictionary<int, TouchPoint> _active = new();
+        public IReadOnlyList<TouchPoint> ActiveTouches => _active.Values.ToArray();
+        public event EventHandler<TouchEventArgs>? TouchBegan;
+        public event EventHandler<TouchEventArgs>? TouchMoved;
+        public event EventHandler<TouchEventArgs>? TouchEnded;
+
+        public void Begin(int id, Point position, long tick)
+        {
+            var point = new TouchPoint(id, position, TouchPhase.Began);
+            _active[id] = point;
+            TouchBegan?.Invoke(this, new TouchEventArgs(point, tick));
+        }
+
+        public void Move(int id, Point position, long tick)
+        {
+            var point = new TouchPoint(id, position, TouchPhase.Moved);
+            _active[id] = point;
+            TouchMoved?.Invoke(this, new TouchEventArgs(point, tick));
+        }
+
+        public void End(int id, Point position, long tick)
+        {
+            _active.Remove(id);
+            TouchEnded?.Invoke(
+                this,
+                new TouchEventArgs(new TouchPoint(id, position, TouchPhase.Ended), tick));
+        }
+    }
+}

--- a/Testing/Gondwana.Tests/Input/TouchInputTests.cs
+++ b/Testing/Gondwana.Tests/Input/TouchInputTests.cs
@@ -1,6 +1,7 @@
 using System.Drawing;
 using Gondwana.Input.Touch;
 using Gondwana.Input.Touch.Gestures;
+using Gondwana.Timers;
 
 namespace Gondwana.Tests.Input;
 

--- a/Testing/Gondwana.Tests/RenderSurfaceHostSceneBindingTests.cs
+++ b/Testing/Gondwana.Tests/RenderSurfaceHostSceneBindingTests.cs
@@ -1,0 +1,85 @@
+using Gondwana.Rendering;
+using Gondwana.Rendering.Backbuffers;
+using Gondwana.Scenes;
+using SkiaSharp;
+
+namespace Gondwana.Tests;
+
+/// <summary>
+/// Verifies the one-render-surface-host-per-scene binding invariant.
+/// </summary>
+public sealed class RenderSurfaceHostSceneBindingTests
+{
+    [Fact]
+    public void Bind_WhenSceneBelongsToAnotherHost_ThrowsWithoutChangingEitherHost()
+    {
+        using var scene = new Scene();
+        using var firstHost = CreateHost();
+        using var secondHost = CreateHost();
+
+        firstHost.Bind(scene);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => secondHost.Bind(scene));
+
+        Assert.Contains(scene.ID, exception.Message);
+        Assert.Same(firstHost, scene.BoundRenderSurfaceHost);
+        Assert.Same(scene, firstHost.Scene);
+        Assert.Same(Scene.Empty, secondHost.Scene);
+    }
+
+    [Fact]
+    public void Bind_WhenHostChangesScenes_ReleasesPreviousScene()
+    {
+        using var firstScene = new Scene();
+        using var secondScene = new Scene();
+        using var firstHost = CreateHost();
+        using var secondHost = CreateHost();
+
+        firstHost.Bind(firstScene);
+        firstHost.Bind(secondScene);
+        secondHost.Bind(firstScene);
+
+        Assert.Same(secondHost, firstScene.BoundRenderSurfaceHost);
+        Assert.Same(firstHost, secondScene.BoundRenderSurfaceHost);
+    }
+
+    [Fact]
+    public void Dispose_ReleasesSceneBinding()
+    {
+        using var scene = new Scene();
+        var host = CreateHost();
+        host.Bind(scene);
+
+        host.Dispose();
+
+        Assert.Null(scene.BoundRenderSurfaceHost);
+    }
+
+    [Fact]
+    public void SceneDispose_ReleasesHostAndRestoresEmptyScene()
+    {
+        var scene = new Scene();
+        using var host = CreateHost();
+        host.Bind(scene);
+
+        scene.Dispose();
+
+        Assert.Null(scene.BoundRenderSurfaceHost);
+        Assert.Same(Scene.Empty, host.Scene);
+    }
+
+    private static RenderSurfaceHost<BitmapBackbuffer> CreateHost() =>
+        new(new TestAdapter(320, 200));
+
+    private sealed class TestAdapter(int width, int height)
+        : RenderSurfaceAdapterBase(width, height)
+    {
+        public override void Present(
+            SKImage bufferImage,
+            SKRectI bufferRect,
+            SKRect destRect)
+        {
+        }
+    }
+}

--- a/Testing/Gondwana.Tests/RenderSurfaceHostSceneBindingTests.cs
+++ b/Testing/Gondwana.Tests/RenderSurfaceHostSceneBindingTests.cs
@@ -1,7 +1,7 @@
+using SkiaSharp;
 using Gondwana.Rendering;
 using Gondwana.Rendering.Backbuffers;
 using Gondwana.Scenes;
-using SkiaSharp;
 
 namespace Gondwana.Tests;
 

--- a/Testing/Gondwana.Tests/TilesheetGtsParityTests.cs
+++ b/Testing/Gondwana.Tests/TilesheetGtsParityTests.cs
@@ -73,7 +73,7 @@ public sealed class TilesheetGtsParityTests : IDisposable
         using var restored = TilesheetFactory.FromDefinition(definition);
 
         Assert.Equal(original.Name, restored.Name);
-        Assert.Equal(original.ImageFilePath, restored.ImageFilePath);
+        Assert.Equal(Path.GetFullPath(original.ImageFilePath), Path.GetFullPath(restored.ImageFilePath));
         Assert.Equal(original.MaskColor, restored.MaskColor);
         Assert.Equal(original.MaskTolerance, restored.MaskTolerance);
         Assert.True(restored.Premultiplied);

--- a/Testing/Gondwana.Tests/TilesheetGtsParityTests.cs
+++ b/Testing/Gondwana.Tests/TilesheetGtsParityTests.cs
@@ -1,0 +1,241 @@
+using System.Drawing;
+using Gondwana.Assets;
+using Gondwana.Drawing;
+using Gondwana.Drawing.Tilesheets;
+using Gondwana.Drawing.Tilesheets.GTS;
+using Gondwana.Physics.Collisions;
+using SkiaSharp;
+
+namespace Gondwana.Tests;
+
+/// <summary>
+/// Verifies parity between runtime tilesheet metadata and the GTS definition model.
+/// </summary>
+public sealed class TilesheetGtsParityTests : IDisposable
+{
+    private readonly string _tempDir = Path.Combine(
+        Path.GetTempPath(),
+        $"GondwanaGtsParityTests_{Guid.NewGuid():N}");
+
+    public TilesheetGtsParityTests()
+    {
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        AssetsFile.ClearAll();
+
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    /// <summary>
+    /// Verifies that all persistent file-backed tilesheet and region metadata survives
+    /// runtime-to-definition-to-runtime conversion.
+    /// </summary>
+    [Fact]
+    public void FileBackedTilesheet_RoundTripsAllPersistentMetadata()
+    {
+        var imagePath = CreateImageFile("sheet.png", 42, 22);
+
+        using var original = TilesheetFactory.FromImageFile(
+            "Logical Sheet Name",
+            imagePath);
+
+        original.RemoveRegion(TilesheetRegion.DefaultRegionName);
+
+        var regionAdjust = new CollisionAdjust(
+            top: 1,
+            bottom: -2,
+            left: 3,
+            right: -4);
+
+        var frameAdjust = new CollisionAdjust(
+            top: 5,
+            bottom: -6,
+            left: 7,
+            right: -8);
+
+        var originalRegion = original.AddRegion(
+            "Actors",
+            new Rectangle(0, 0, 42, 22),
+            new Size(16, 16),
+            tilePadding: new Spacing(0, 0, 2, 0),
+            regionMargin: new Spacing(2, 2, 4, 4),
+            overhangPixels: new Spacing(1, 2, 3, 4),
+            collisionAdjust: regionAdjust);
+
+        originalRegion.SetFrameCollisionAdjust(1, 0, frameAdjust);
+        original.ApplyMask(new SKColor(10, 20, 30, 255), tolerance: 7);
+
+        var definition = TilesheetDefinitionSerializer.FromTilesheet(original);
+        using var restored = TilesheetFactory.FromDefinition(definition);
+
+        Assert.Equal(original.Name, restored.Name);
+        Assert.Equal(original.ImageFilePath, restored.ImageFilePath);
+        Assert.Equal(original.MaskColor, restored.MaskColor);
+        Assert.Equal(original.MaskTolerance, restored.MaskTolerance);
+        Assert.True(restored.Premultiplied);
+        Assert.Null(restored.AssetIdentifier);
+
+        var restoredRegion = Assert.Single(restored.Regions);
+        Assert.Equal(originalRegion.Name, restoredRegion.Name);
+        Assert.Equal(originalRegion.Area, restoredRegion.Area);
+        Assert.Equal(originalRegion.TileSize, restoredRegion.TileSize);
+        Assert.Equal(originalRegion.TilePadding, restoredRegion.TilePadding);
+        Assert.Equal(originalRegion.RegionMargin, restoredRegion.RegionMargin);
+        Assert.Equal(originalRegion.Overhang, restoredRegion.Overhang);
+        Assert.Equal(originalRegion.CollisionAdjust, restoredRegion.CollisionAdjust);
+        Assert.Equal(
+            originalRegion.GetFrameCollisionAdjust(0, 0),
+            restoredRegion.GetFrameCollisionAdjust(0, 0));
+        Assert.Equal(
+            originalRegion.GetFrameCollisionAdjust(1, 0),
+            restoredRegion.GetFrameCollisionAdjust(1, 0));
+    }
+
+    /// <summary>
+    /// Verifies that an asset entry name does not replace the logical name declared by GTS.
+    /// </summary>
+    [Fact]
+    public void AssetBackedDefinition_UsesDefinitionNameRatherThanAssetEntryName()
+    {
+        var assetsPath = Path.Combine(_tempDir, "tiles.gaf");
+        using var assetsFile = AssetsFile.LoadOrCreate(assetsPath);
+        using var imageStream = CreateImageStream(16, 16);
+        assetsFile.Add(AssetTypes.Image, "images/player.png", imageStream);
+
+        var definition = new TilesheetDefinition
+        {
+            Name = "Player Sprites",
+            Image = new TilesheetImageDefinition
+            {
+                AssetEntryName = "images/player.png"
+            },
+            Regions =
+            [
+                new TilesheetRegionDefinition
+                {
+                    Name = TilesheetRegion.DefaultRegionName,
+                    Area = new Rectangle(0, 0, 16, 16),
+                    TileSize = new Size(16, 16)
+                }
+            ]
+        };
+
+        using var tilesheet = TilesheetFactory.FromDefinition(
+            definition,
+            defaultAssetsFile: assetsFile);
+
+        Assert.Equal("Player Sprites", tilesheet.Name);
+        Assert.NotNull(tilesheet.AssetIdentifier);
+        Assert.Equal("images/player.png", tilesheet.AssetIdentifier.AssetName);
+        Assert.Same(assetsFile, tilesheet.AssetIdentifier.AssetsFile);
+    }
+
+    /// <summary>
+    /// Verifies that premultiplication without a mask survives a GTS round trip.
+    /// </summary>
+    [Fact]
+    public void PremultipliedTilesheet_WithoutMask_RoundTrips()
+    {
+        var imagePath = CreateImageFile("premultiplied.png", 16, 16);
+
+        using var original = TilesheetFactory.FromImageFile("Premultiplied", imagePath);
+        original.ApplyPremultiplyAlpha();
+
+        var definition = TilesheetDefinitionSerializer.FromTilesheet(original);
+        using var restored = TilesheetFactory.FromDefinition(definition);
+
+        Assert.True(definition.PremultiplyAlpha);
+        Assert.Null(definition.Mask);
+        Assert.True(restored.Premultiplied);
+        Assert.Null(restored.MaskColor);
+    }
+
+    /// <summary>
+    /// Verifies that mutually exclusive image sources are rejected instead of being
+    /// resolved by undocumented precedence.
+    /// </summary>
+    [Fact]
+    public void Definition_WithFileAndAssetImageSources_Throws()
+    {
+        var definition = new TilesheetDefinition
+        {
+            Name = "Ambiguous",
+            Image = new TilesheetImageDefinition
+            {
+                FilePath = "sheet.png",
+                AssetsFilePath = "tiles.gaf",
+                AssetEntryName = "sheet.png"
+            }
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => TilesheetFactory.FromDefinition(definition, _tempDir));
+
+        Assert.Contains("ambiguous", exception.Message.ToLowerInvariant());
+    }
+
+    /// <summary>
+    /// Verifies that an assets-file path without an entry name is rejected clearly.
+    /// </summary>
+    [Fact]
+    public void Definition_WithAssetsFileButNoEntryName_Throws()
+    {
+        var definition = new TilesheetDefinition
+        {
+            Name = "Incomplete",
+            Image = new TilesheetImageDefinition
+            {
+                AssetsFilePath = "tiles.gaf"
+            }
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => TilesheetFactory.FromDefinition(definition, _tempDir));
+
+        Assert.Contains(
+            nameof(TilesheetImageDefinition.AssetEntryName),
+            exception.Message);
+    }
+
+    /// <summary>
+    /// Documents that a runtime-only bitmap has no persistent image source to write to GTS.
+    /// </summary>
+    [Fact]
+    public void BitmapBackedTilesheet_CannotBeConvertedWithoutPersistentImageSource()
+    {
+        using var tilesheet = TilesheetFactory.FromBitmap(
+            "In Memory",
+            new SKBitmap(16, 16));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => TilesheetDefinitionSerializer.FromTilesheet(tilesheet));
+
+        Assert.Contains(
+            "no ImageFilePath or AssetIdentifier",
+            exception.Message);
+    }
+
+    private string CreateImageFile(string fileName, int width, int height)
+    {
+        var path = Path.Combine(_tempDir, fileName);
+        using var stream = CreateImageStream(width, height);
+        using var file = File.Create(path);
+        stream.CopyTo(file);
+        return path;
+    }
+
+    private static MemoryStream CreateImageStream(int width, int height)
+    {
+        using var bitmap = new SKBitmap(width, height);
+        bitmap.Erase(new SKColor(40, 80, 120, 200));
+
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+
+        return new MemoryStream(data.ToArray());
+    }
+}


### PR DESCRIPTION
- Tightened touch input handling with improved gesture recognizers (pinch, swipe, tap) and new `PinchPhase`/`PinchedEve
- Fixed `MouseEventPoller` scroll detection for persistent-delta adapters and resolved `RenderSurfaceHost` dispose/dupl
- Refactored `WidgetInputRouter` and widget classes for cleaner input routing; limited one `RenderSurfaceHost` per `Sce
- Added `TilesheetFactory`, expanded test coverage for GPU refresh queue, mouse/touch input, and render surface host sc
- xml comments for RenderToBackbufferBitmap; also removed duplicate call to RenderBackbufferEnd?.Invoke()
- splitting Bitmap and GPU RenderToBackbuffer calls into two separate private methods
- removed vestigial call from GL rendering path to RefreshQueue
- Enforce a one-render-surface-host-per-scene binding rule and update render paths to separate GPU full-frame vs bitmap dirty-region rendering.
- Make `RefreshQueue` conditionally writable based on scene rendering policy (dirty-region vs full-frame) and add GPU refresh-queue tests.
- Improve input systems: singleton reset/disposal semantics, touch lifecycle correctness (began queue), and more robust tap/swipe/pinch gesture recognition; add input tests.