### PR TITLE
fix(core): fix hex partial coordinate movement bug

### DIFF
--- a/Demos/Gondwana.CoordinateTest/Game.cs
+++ b/Demos/Gondwana.CoordinateTest/Game.cs
@@ -244,8 +244,8 @@ public class Game : IDisposable
     private Scene? CreateInitialScene()
     {
         var scene = new Scene();
-        var sceneLayer1 = scene.AddLayer(60, 5, 64, 64, 10, 1f, CoordinateSystemTypes.Orthogonal);
-        var sceneLayer2 = scene.AddLayer(60, 5, 32, 32, 5, 0.5f, CoordinateSystemTypes.Orthogonal);
+        var sceneLayer1 = scene.AddLayer(60, 5, 64, 64, 10, 1f, CoordinateSystemTypes.HexAxialPointedTop);
+        var sceneLayer2 = scene.AddLayer(60, 5, 32, 32, 5, 0.5f, CoordinateSystemTypes.HexAxialPointedTop);
 
         sceneLayer1.ShowGridLines = true;
         sceneLayer1.ShowCollisionBoxes = true;

--- a/Gondwana/Drawing/Coordinates/HexAxialFlatTopCoordinates.cs
+++ b/Gondwana/Drawing/Coordinates/HexAxialFlatTopCoordinates.cs
@@ -17,16 +17,25 @@ internal sealed class HexAxialFlatTopCoordinates : ISceneLayerCoordinates
     /// <returns>The pixel position of the tile's anchor point.</returns>
     public Point GetAnchorPixelAtSceneLayerCoordinates(SceneLayer sceneLayer, PointF gp)
     {
-        int W = sceneLayer.TileWidth;
-        int H = sceneLayer.TileHeight;
-        int col = (int)Math.Round(gp.X);
-        int row = (int)Math.Round(gp.Y);
+        int width = sceneLayer.TileWidth;
+        int height = sceneLayer.TileHeight;
+
+        // The layout uses even-q offset coordinates. Interpolate the
+        // staggered Y offset between the surrounding integer columns.
+        int baseColumn = (int)MathF.Floor(gp.X);
+        float columnProgress = gp.X - baseColumn;
+
+        // Preserve the existing integer-division behavior for odd tile heights.
+        float halfHeight = height / 2;
+        float currentColumnOffsetY = (baseColumn & 1) == 0 ? 0f : halfHeight;
+        float nextColumnOffsetY = ((baseColumn + 1) & 1) == 0 ? 0f : halfHeight;
+        float offsetY = currentColumnOffsetY + ((nextColumnOffsetY - currentColumnOffsetY) * columnProgress);
 
         var origin = sceneLayer.OriginPx;
-        int x = (int)Math.Floor(-origin.X + col * (W * 0.75f));
-        int y = (int)Math.Floor(-origin.Y + row * (double)H + ((col & 1) == 0 ? 0 : H / 2));
+        float x = -origin.X + (gp.X * width * 0.75f);
+        float y = -origin.Y + (gp.Y * height) + offsetY;
 
-        return new Point(x, y);
+        return new Point((int)MathF.Floor(x), (int)MathF.Floor(y));
     }
 
     /// <summary>

--- a/Gondwana/Drawing/Coordinates/HexAxialPointedTop.cs
+++ b/Gondwana/Drawing/Coordinates/HexAxialPointedTop.cs
@@ -17,17 +17,27 @@ internal sealed class HexAxialPointedTop : ISceneLayerCoordinates
     /// <returns>The pixel position of the tile's anchor point.</returns>
     public Point GetAnchorPixelAtSceneLayerCoordinates(SceneLayer sceneLayer, PointF gp)
     {
-        int W = sceneLayer.TileWidth;
-        int H = sceneLayer.TileHeight;
-        int col = (int)Math.Round(gp.X);
-        int row = (int)Math.Round(gp.Y);
+        int width = sceneLayer.TileWidth;
+        int height = sceneLayer.TileHeight;
 
-        int originX = sceneLayer.OriginPx.X;
-        int originY = sceneLayer.OriginPx.Y;
+        // The layout uses even-r offset coordinates. Interpolate the
+        // staggered X offset between the surrounding integer rows.
+        int baseRow = (int)MathF.Floor(gp.Y);
+        float rowProgress = gp.Y - baseRow;
 
-        int x = -originX + col * W + ((row & 1) == 0 ? 0 : W / 2);
-        int y = -originY + (int)Math.Floor(row * (H * 0.75f));
-        return new Point(x, y);
+        // Preserve the existing integer-division behavior for odd tile widths.
+        float halfWidth = width / 2;
+        float currentRowOffsetX = (baseRow & 1) == 0 ? 0f : halfWidth;
+        float nextRowOffsetX = ((baseRow + 1) & 1) == 0 ? 0f : halfWidth;
+        float offsetX = currentRowOffsetX + ((nextRowOffsetX - currentRowOffsetX) * rowProgress);
+        var origin = sceneLayer.OriginPx;
+
+        float x = -origin.X + (gp.X * width) + offsetX;
+        float y = -origin.Y + (gp.Y * height * 0.75f);
+
+        return new Point(
+            (int)MathF.Floor(x),
+            (int)MathF.Floor(y));
     }
 
     /// <summary>


### PR DESCRIPTION
- Fixed a bug where hex grid movement with partial coordinates produced incorrect results for flat-top and pointed-top
- Updated `HexAxialFlatTopCoordinates` and `HexAxialPointedTop` coordinate classes with improved movement calculations
- Adjusted the coordinate test demo (`Game.cs`) to reflect corrected behavior