### PR TITLE
feat(widgets): add hyperlink widget and container refactor

### DIFF
--- a/Gondwana.Widgets/ContainerWidget.cs
+++ b/Gondwana.Widgets/ContainerWidget.cs
@@ -10,16 +10,32 @@ namespace Gondwana.Widgets;
 /// <see cref="DirectComposite"/> child system.
 /// </summary>
 /// <remarks>
-/// Direct-drawing children and widget children share the same composite anchor,
-/// offset storage, target validation, movement, and disposal ownership.
+/// Direct-drawing children and widget children share the same composite
+/// anchor, offset storage, target validation, movement, and disposal
+/// ownership. Widget children additionally participate in lifecycle
+/// propagation and keyboard-input bubbling.
 /// </remarks>
 public abstract class ContainerWidget : WidgetBase
 {
     private bool _isShown;
 
+    #region constructors
+
     /// <summary>
     /// Initializes a new instance of the <see cref="ContainerWidget"/> class.
     /// </summary>
+    /// <param name="renderSurfaceHost">
+    /// The render surface host that owns the widget.
+    /// </param>
+    /// <param name="mode">
+    /// The drawing mode used by the widget and its children.
+    /// </param>
+    /// <param name="anchor">
+    /// The widget anchor in mode-appropriate pixels.
+    /// </param>
+    /// <param name="nickname">
+    /// An optional diagnostic nickname.
+    /// </param>
     protected ContainerWidget(RenderSurfaceHostBase renderSurfaceHost,
                               DirectDrawingMode mode,
                               PointF anchor = default,
@@ -28,34 +44,100 @@ public abstract class ContainerWidget : WidgetBase
     {
     }
 
+    #endregion constructors
+
+    #region public properties
+
     /// <summary>
     /// Gets a snapshot of the child widgets directly owned by this container.
     /// </summary>
     public IReadOnlyList<WidgetBase> ChildWidgets => Children.OfType<WidgetBase>().ToArray();
 
+    #endregion public properties
+
+    #region public methods
+
+    /// <inheritdoc/>
+    public override DirectComposite Add(IDirectCompositeChild child,
+                                        bool keepCurrentOffset = true,
+                                        Vector2? explicitLocalOffsetPx = null)
+    {
+        ArgumentNullException.ThrowIfNull(child);
+
+        bool alreadyAdded =
+            Children.Contains(child);
+
+        base.Add(
+            child,
+            keepCurrentOffset,
+            explicitLocalOffsetPx);
+
+        if (!alreadyAdded &&
+            _isShown &&
+            child is WidgetBase widget)
+        {
+            widget.Show();
+        }
+
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public override DirectComposite Remove(
+        IDirectCompositeChild child)
+    {
+        ArgumentNullException.ThrowIfNull(child);
+
+        if (_isShown &&
+            child is WidgetBase widget &&
+            Children.Contains(child))
+        {
+            widget.Hide();
+        }
+
+        return base.Remove(child);
+    }
+
+    /// <inheritdoc/>
+    public override DirectComposite Clear()
+    {
+        if (_isShown)
+        {
+            foreach (WidgetBase child in GetChildWidgetSnapshot())
+                child.Hide();
+        }
+
+        return base.Clear();
+    }
+
+    #endregion public methods
+
+    #region protected methods
+
     /// <summary>
     /// Adds a child widget at a local offset from this container's anchor.
     /// </summary>
-    /// <typeparam name="TWidget">The child widget type.</typeparam>
-    /// <param name="widget">The widget to add.</param>
-    /// <param name="localOffsetPx">The local offset from the container anchor.</param>
+    /// <typeparam name="TWidget">
+    /// The child widget type.
+    /// </typeparam>
+    /// <param name="widget">
+    /// The widget to add.
+    /// </param>
+    /// <param name="localOffsetPx">
+    /// The local offset from the container anchor.
+    /// </param>
     /// <returns>The added widget.</returns>
-    protected TWidget AddChild<TWidget>(TWidget widget,
-                                        Vector2 localOffsetPx)
-                                        where TWidget : WidgetBase
+    protected TWidget Add<TWidget>(
+        TWidget widget,
+        Vector2 localOffsetPx)
+        where TWidget : WidgetBase
     {
         ArgumentNullException.ThrowIfNull(widget);
 
-        if (Children.Contains(widget))
-            return widget;
-
-        Add(widget, keepCurrentOffset: false, explicitLocalOffsetPx: localOffsetPx);
-
-        widget.KeyboardInput += OnChildKeyboardInput;
-        widget.Disposing += OnChildDisposing;
-
-        if (_isShown)
-            widget.Show();
+        Add(
+            (IDirectCompositeChild)widget,
+            keepCurrentOffset: false,
+            explicitLocalOffsetPx: localOffsetPx);
 
         return widget;
     }
@@ -63,26 +145,25 @@ public abstract class ContainerWidget : WidgetBase
     /// <summary>
     /// Removes a child widget from the container.
     /// </summary>
-    /// <param name="widget">The widget to remove.</param>
+    /// <param name="widget">
+    /// The widget to remove.
+    /// </param>
     /// <param name="dispose">
-    /// <see langword="true"/> to dispose the child after detaching it.
+    /// <see langword="true"/> to dispose the child after detaching it;
+    /// otherwise, <see langword="false"/>.
     /// </param>
     /// <returns>
     /// <see langword="true"/> when the widget was a direct child; otherwise,
     /// <see langword="false"/>.
     /// </returns>
-    protected bool RemoveChild(WidgetBase widget, bool dispose = false)
+    protected bool RemoveChild(
+        WidgetBase widget,
+        bool dispose = false)
     {
         ArgumentNullException.ThrowIfNull(widget);
 
         if (!Children.Contains(widget))
             return false;
-
-        if (_isShown)
-            widget.Hide();
-
-        widget.KeyboardInput -= OnChildKeyboardInput;
-        widget.Disposing -= OnChildDisposing;
 
         Remove(widget);
 
@@ -90,6 +171,26 @@ public abstract class ContainerWidget : WidgetBase
             widget.Dispose();
 
         return true;
+    }
+
+    /// <inheritdoc/>
+    protected override void OnChildAdded(
+        IDirectCompositeChild child)
+    {
+        base.OnChildAdded(child);
+
+        if (child is WidgetBase widget)
+            widget.KeyboardInput += OnChildKeyboardInput;
+    }
+
+    /// <inheritdoc/>
+    protected override void OnChildRemoved(
+        IDirectCompositeChild child)
+    {
+        if (child is WidgetBase widget)
+            widget.KeyboardInput -= OnChildKeyboardInput;
+
+        base.OnChildRemoved(child);
     }
 
     /// <inheritdoc/>
@@ -119,8 +220,8 @@ public abstract class ContainerWidget : WidgetBase
     {
         base.ProcessActivated();
 
-        // Children are activated after their parent so they are later in the
-        // router's hit-test order.
+        // Children are activated after their parent so they appear later in
+        // the router's hit-test order.
         foreach (WidgetBase child in GetChildWidgetSnapshot())
             child.Activate();
     }
@@ -134,42 +235,34 @@ public abstract class ContainerWidget : WidgetBase
         base.ProcessCancelled();
     }
 
-    /// <inheritdoc/>
-    public override void Dispose()
-    {
-        foreach (WidgetBase child in GetChildWidgetSnapshot())
-        {
-            child.KeyboardInput -= OnChildKeyboardInput;
-            child.Disposing -= OnChildDisposing;
-        }
+    #endregion protected methods
 
-        base.Dispose();
-    }
+    #region private methods
 
-    private void OnChildKeyboardInput(WidgetKeyboardEventArgs args)
+    private void OnChildKeyboardInput(
+        WidgetKeyboardEventArgs args)
     {
         if (args.Handled)
             return;
 
-        var parentArgs = new WidgetKeyboardEventArgs(this,
-                                                     args.Key,
-                                                     args.KeyAction,
-                                                     args.Modifiers,
-                                                     args.Tick);
+        var parentArgs = new WidgetKeyboardEventArgs(
+            this,
+            args.Key,
+            args.KeyAction,
+            args.Modifiers,
+            args.Tick);
 
         DispatchKeyboardInput(parentArgs);
 
         args.Handled = parentArgs.Handled;
     }
 
-    private void OnChildDisposing(object? sender, IDirectDrawable child)
+    private WidgetBase[] GetChildWidgetSnapshot()
     {
-        if (child is not WidgetBase widget)
-            return;
-
-        widget.KeyboardInput -= OnChildKeyboardInput;
-        widget.Disposing -= OnChildDisposing;
+        return Children
+            .OfType<WidgetBase>()
+            .ToArray();
     }
 
-    private WidgetBase[] GetChildWidgetSnapshot() => Children.OfType<WidgetBase>().ToArray();
+    #endregion private methods
 }

--- a/Gondwana.Widgets/Controls/HyperlinkWidget.cs
+++ b/Gondwana.Widgets/Controls/HyperlinkWidget.cs
@@ -56,9 +56,11 @@ public sealed class HyperlinkWidget : WidgetBase
         ArgumentNullException.ThrowIfNull(view);
         ArgumentNullException.ThrowIfNull(navigateUri);
 
+        if (!navigateUri.IsAbsoluteUri)
+            throw new ArgumentException("The URI must be absolute.", nameof(navigateUri));
+
         _uriLauncher = uriLauncher;
         NavigateUri = navigateUri;
-
         Label = CreateLabel(renderSurfaceHost, view, bounds, text);
 
         Add(Label);

--- a/Gondwana.Widgets/Controls/HyperlinkWidget.cs
+++ b/Gondwana.Widgets/Controls/HyperlinkWidget.cs
@@ -1,0 +1,224 @@
+﻿using System.Drawing;
+using SkiaSharp;
+using Gondwana.Drawing.Direct;
+using Gondwana.Input.Keyboard;
+using Gondwana.Rendering;
+using Gondwana.Rendering.Views;
+using Gondwana.Scenes;
+
+namespace Gondwana.Widgets.Controls;
+
+/// <summary>
+/// Represents an interactive text link that opens an external URI.
+/// </summary>
+public sealed class HyperlinkWidget : WidgetBase
+{
+    private readonly IExternalUriLauncher _uriLauncher;
+    private readonly SKColor _normalColor = new(80, 150, 255);
+    private readonly SKColor _hoverColor = new(125, 185, 255);
+
+    #region events
+
+    /// <summary>
+    /// Occurs after the link has been opened successfully.
+    /// </summary>
+    public event Action<Uri>? LinkOpened;
+
+    /// <summary>
+    /// Occurs when an attempt to open the link fails.
+    /// </summary>
+    public event Action<Uri, Exception>? LinkOpenFailed;
+
+    #endregion
+
+    #region constructors
+
+    /// <summary>
+    /// Initializes a view-level hyperlink widget.
+    /// </summary>
+    /// <param name="uriLauncher">The service used to open external URIs.</param>
+    /// <param name="renderSurfaceHost">The render surface host.</param>
+    /// <param name="view">The view to associate the widget with.</param>
+    /// <param name="bounds">The bounds of the widget.</param>
+    /// <param name="text">The text to display for the link.</param>
+    /// <param name="navigateUri">The URI to navigate to when the link is activated.</param>
+    /// <param name="nickname">An optional nickname for the widget.</param>
+    public HyperlinkWidget(IExternalUriLauncher uriLauncher,
+                           RenderSurfaceHostBase renderSurfaceHost,
+                           View view,
+                           Rectangle bounds,
+                           string text,
+                           Uri navigateUri,
+                           string? nickname = null)
+        : base(renderSurfaceHost, DirectDrawingMode.View, bounds.Location, nickname)
+    {
+        ArgumentNullException.ThrowIfNull(uriLauncher);
+        ArgumentNullException.ThrowIfNull(view);
+        ArgumentNullException.ThrowIfNull(navigateUri);
+
+        _uriLauncher = uriLauncher;
+        NavigateUri = navigateUri;
+
+        Label = CreateLabel(renderSurfaceHost, view, bounds, text);
+
+        Add(Label);
+        CompleteInitialization();
+    }
+
+    /// <summary>
+    /// Initializes a scene-layer hyperlink widget.
+    /// </summary>
+    /// <param name="uriLauncher">The service used to open external URIs.</param>
+    /// <param name="renderSurfaceHost">The render surface host.</param>
+    /// <param name="sceneLayer">The scene layer to associate the widget with.</param>
+    /// <param name="bounds">The bounds of the widget.</param>
+    /// <param name="text">The text to display for the link.</param>
+    /// <param name="navigateUri">The URI to navigate to when the link is activated.</param>
+    /// <param name="nickname">An optional nickname for the widget.</param>
+    public HyperlinkWidget(IExternalUriLauncher uriLauncher,
+                           RenderSurfaceHostBase renderSurfaceHost,
+                           SceneLayer sceneLayer,
+                           Rectangle bounds,
+                           string text,
+                           Uri navigateUri,
+                           string? nickname = null)
+        : base(renderSurfaceHost, DirectDrawingMode.SceneLayer, bounds.Location, nickname)
+    {
+        ArgumentNullException.ThrowIfNull(uriLauncher);
+        ArgumentNullException.ThrowIfNull(sceneLayer);
+        ArgumentNullException.ThrowIfNull(navigateUri);
+
+        _uriLauncher = uriLauncher;
+        NavigateUri = navigateUri;
+
+        Label = CreateLabel(renderSurfaceHost, sceneLayer, bounds, text);
+
+        Add(Label);
+        CompleteInitialization();
+    }
+
+    #endregion constructors
+
+    #region public properties
+
+    /// <summary>
+    /// Gets or sets the URI opened when the widget is activated.
+    /// </summary>
+    public Uri NavigateUri { get; set; }
+
+    /// <summary>
+    /// Gets the text block used to display the link.
+    /// </summary>
+    public TextBlock Label { get; }
+
+    #endregion public properties
+    
+    #region public methods
+
+    /// <summary>
+    /// Opens the configured URI.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A <see cref="ValueTask"/> representing the asynchronous operation.</returns>
+    public async ValueTask OpenAsync(CancellationToken cancellationToken = default)
+    {
+        if (!IsInputEnabled)
+            return;
+
+        Uri uri = NavigateUri;
+
+        try
+        {
+            await _uriLauncher.OpenAsync(uri, cancellationToken);
+            LinkOpened?.Invoke(uri);
+        }
+        catch (Exception ex)
+        {
+            LinkOpenFailed?.Invoke(uri, ex);
+        }
+    }
+
+    #endregion public methods
+
+    #region protected methods
+
+    /// <inheritdoc/>
+    protected override void OnPointerEnter(WidgetPointerEventArgs args)
+    {
+        base.OnPointerEnter(args);
+        Label.SetColors(_hoverColor, SKColors.Transparent);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnPointerLeave(WidgetPointerEventArgs args)
+    {
+        base.OnPointerLeave(args);
+        Label.SetColors(_normalColor, SKColors.Transparent);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnPointerClick(WidgetPointerEventArgs args)
+    {
+        base.OnPointerClick(args);
+
+        if (!args.IsPrimaryButton)
+            return;
+
+        args.Handled = true;
+        _ = OpenAsync();
+    }
+
+    /// <inheritdoc/>
+    protected override void OnKeyboardInput(WidgetKeyboardEventArgs args)
+    {
+        base.OnKeyboardInput(args);
+
+        if (args.KeyAction != KeyAction.Pressed)
+            return;
+
+        // Standard Enter and Space virtual-key values.
+        if (args.Key is not 13 and not 32)
+            return;
+
+        args.Handled = true;
+        _ = OpenAsync();
+    }
+
+    #endregion protected methods
+
+    #region private methods
+
+    private void CompleteInitialization()
+    {
+        CanReceiveFocus = true;
+        IsKeyboardInputEnabled = true;
+    }
+
+    private TextBlock CreateLabel(RenderSurfaceHostBase host,
+                                  View view,
+                                  Rectangle bounds,
+                                  string text)
+    {
+        return new TextBlock(host, view, bounds)
+            .SetText(text)
+            .SetFont(SKTypeface.Default, 16f, minSize: 10f)
+            .SetColors(_normalColor, SKColors.Transparent)
+            .SetAlignment(SKTextAlign.Left, TextBlock.VerticalAlign.Center)
+            .EnableWrapping(false);
+    }
+
+    private TextBlock CreateLabel(RenderSurfaceHostBase host,
+                                  SceneLayer layer,
+                                  Rectangle bounds,
+                                  string text)
+    {
+        return new TextBlock(host, layer, view: null, worldBounds: bounds)
+            .SetText(text)
+            .SetFont(SKTypeface.Default, 16f, minSize: 10f)
+            .SetColors(_normalColor, SKColors.Transparent)
+            .SetAlignment(SKTextAlign.Left, TextBlock.VerticalAlign.Center)
+            .EnableWrapping(false);
+    }
+
+    #endregion private methods
+}

--- a/Gondwana.Widgets/Controls/IExternalUriLauncher.cs
+++ b/Gondwana.Widgets/Controls/IExternalUriLauncher.cs
@@ -1,0 +1,25 @@
+﻿namespace Gondwana.Widgets.Controls;
+
+/// <summary>
+/// Defines a platform-specific service for opening external URIs.
+/// </summary>
+public interface IExternalUriLauncher
+{
+    /// <summary>
+    /// Opens the specified URI using the platform's external URI handler.
+    /// </summary>
+    /// <param name="uri">The absolute URI to open.</param>
+    /// <param name="cancellationToken">
+    /// A token used to request cancellation of the operation.
+    /// </param>
+    /// <returns>
+    /// A task representing the asynchronous open operation.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="uri"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the current platform cannot open the specified URI.
+    /// </exception>
+    ValueTask OpenAsync(Uri uri, CancellationToken cancellationToken = default);
+}

--- a/Gondwana.Widgets/Dialogs/AboutBox.cs
+++ b/Gondwana.Widgets/Dialogs/AboutBox.cs
@@ -75,12 +75,17 @@ public sealed class AboutBox : DialogBox
         {
             if (uriLauncher is null)
             {
-                throw new ArgumentNullException(nameof(uriLauncher), "A URI launcher is required when a hyperlink URI is provided.");
+                throw new ArgumentNullException(nameof(uriLauncher), "A URI launcher is required when configuring the hyperlink.");
             }
 
             if (hyperlinkUri is null)
             {
-                throw new ArgumentNullException(nameof(hyperlinkUri), "A hyperlink URI is required when a URI launcher is provided.");
+                throw new ArgumentNullException(nameof(hyperlinkUri), "A hyperlink URI is required when configuring the hyperlink.");
+            }
+
+            if (!hyperlinkUri.IsAbsoluteUri)
+            {
+                throw new ArgumentException("The hyperlink URI must be absolute.", nameof(hyperlinkUri));
             }
         }
 

--- a/Gondwana.Widgets/Dialogs/AboutBox.cs
+++ b/Gondwana.Widgets/Dialogs/AboutBox.cs
@@ -34,6 +34,15 @@ public sealed class AboutBox : DialogBox
     /// Optional dialog bounds. When omitted, the dialog is centered in the view.
     /// </param>
     /// <param name="nickname">An optional diagnostic nickname.</param>
+    /// <param name="uriLauncher">
+    /// The optional platform service used to open the hyperlink URI.
+    /// </param>
+    /// <param name="hyperlinkUri">
+    /// The optional external URI displayed by the dialog.
+    /// </param>
+    /// <param name="hyperlinkText">
+    /// The optional hyperlink display text. When omitted, the URI is displayed.
+    /// </param>
     public AboutBox(RenderSurfaceHostBase renderSurfaceHost,
                     View view,
                     string applicationName,
@@ -42,7 +51,10 @@ public sealed class AboutBox : DialogBox
                     string? copyright = null,
                     SKImage? logo = null,
                     Rectangle? bounds = null,
-                    string? nickname = null)
+                    string? nickname = null,
+                    IExternalUriLauncher? uriLauncher = null,
+                    Uri? hyperlinkUri = null,
+                    string? hyperlinkText = null)
         : base(renderSurfaceHost,
                view,
                ResolveBounds(view, bounds),
@@ -54,6 +66,23 @@ public sealed class AboutBox : DialogBox
         Version = version;
         Description = description;
         Copyright = copyright;
+
+        bool hasHyperlinkConfiguration = uriLauncher is not null ||
+                                         hyperlinkUri is not null ||
+                                         hyperlinkText is not null;
+
+        if (hasHyperlinkConfiguration)
+        {
+            if (uriLauncher is null)
+            {
+                throw new ArgumentNullException(nameof(uriLauncher), "A URI launcher is required when a hyperlink URI is provided.");
+            }
+
+            if (hyperlinkUri is null)
+            {
+                throw new ArgumentNullException(nameof(hyperlinkUri), "A hyperlink URI is required when a URI launcher is provided.");
+            }
+        }
 
         Rectangle resolvedBounds = ResolveBounds(view, bounds);
 
@@ -103,6 +132,26 @@ public sealed class AboutBox : DialogBox
         VersionText.ZOrder = 10_002;
         Add(VersionText);
 
+        if (uriLauncher is not null && hyperlinkUri is not null)
+        {
+            Rectangle hyperlinkBounds = new(contentLeft,
+                                            contentTop + 74,
+                                            resolvedBounds.Right - contentRightPadding - contentLeft,
+                                            28);
+
+            Hyperlink = new HyperlinkWidget(uriLauncher,
+                                            renderSurfaceHost,
+                                            view,
+                                            hyperlinkBounds,
+                                            hyperlinkText ?? hyperlinkUri.ToString(),
+                                            hyperlinkUri,
+                                            $"{Nickname}.hyperlink");
+
+            Hyperlink.Label.ZOrder = 10_002;
+            Add(Hyperlink, new Vector2(hyperlinkBounds.Left - resolvedBounds.Left,
+                                                   hyperlinkBounds.Top - resolvedBounds.Top));
+        }
+
         var detailsTextScreenBounds = new Rectangle(resolvedBounds.Left + 24, contentTop + 126, resolvedBounds.Width - 48, resolvedBounds.Height - 222);
         string detailText = string.Join(Environment.NewLine + Environment.NewLine,
                                         new[] { description, copyright }
@@ -123,7 +172,7 @@ public sealed class AboutBox : DialogBox
         Rectangle okBounds = new(resolvedBounds.Right - 116, resolvedBounds.Bottom - 54, 92, 34);
         OkButton = new ButtonWidget(renderSurfaceHost, view, okBounds, "OK", $"{Nickname}.ok");
 
-        AddChild(OkButton, new Vector2(resolvedBounds.Width - 116, resolvedBounds.Height - 54));
+        Add(OkButton, new Vector2(resolvedBounds.Width - 116, resolvedBounds.Height - 54));
 
         OkButton.SetButtonZOrder(10_003);
         OkButton.Clicked += OnOkClicked;
@@ -177,6 +226,11 @@ public sealed class AboutBox : DialogBox
     /// Gets the OK button.
     /// </summary>
     public ButtonWidget OkButton { get; }
+
+    /// <summary>
+    /// Gets the optional external hyperlink displayed by the dialog.
+    /// </summary>
+    public HyperlinkWidget? Hyperlink { get; }
 
     #endregion public properties
 

--- a/Gondwana.Widgets/Dialogs/DialogBox.cs
+++ b/Gondwana.Widgets/Dialogs/DialogBox.cs
@@ -58,7 +58,7 @@ public abstract class DialogBox : DraggableContainerWidget
         if (showCloseButton)
         {
             CloseButton = CreateCloseButton(renderSurfaceHost, view, bounds);
-            AddChild(CloseButton, GetCloseButtonOffset(bounds.Size));
+            Add(CloseButton, GetCloseButtonOffset(bounds.Size));
 
             CloseButton.Clicked += OnCloseButtonClicked;
         }
@@ -92,7 +92,7 @@ public abstract class DialogBox : DraggableContainerWidget
         if (showCloseButton)
         {
             CloseButton = CreateCloseButton(renderSurfaceHost, sceneLayer, bounds);
-            AddChild(CloseButton, GetCloseButtonOffset(bounds.Size));
+            Add(CloseButton, GetCloseButtonOffset(bounds.Size));
 
             CloseButton.Clicked += OnCloseButtonClicked;
         }

--- a/Gondwana.Widgets/WidgetBase.cs
+++ b/Gondwana.Widgets/WidgetBase.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+using System.Numerics;
 using Gondwana.Drawing.Direct;
 using Gondwana.Rendering;
 using Gondwana.Rendering.Views;

--- a/Gondwana.Widgets/WidgetBase.cs
+++ b/Gondwana.Widgets/WidgetBase.cs
@@ -1,5 +1,4 @@
 ﻿using System.Drawing;
-using System.Numerics;
 using Gondwana.Drawing.Direct;
 using Gondwana.Rendering;
 using Gondwana.Rendering.Views;

--- a/Gondwana/Drawing/Direct/DirectComposite.cs
+++ b/Gondwana/Drawing/Direct/DirectComposite.cs
@@ -25,7 +25,7 @@ namespace Gondwana.Drawing.Direct;
 /// relationships are rejected.
 /// </para>
 /// </remarks>
-public class DirectComposite : IDirectCompositeChild
+public class DirectComposite : IDirectCompositeChild, IDirectCompositeContainer
 {
     private static readonly object _parentSyncRoot = new();
 
@@ -42,10 +42,16 @@ public class DirectComposite : IDirectCompositeChild
     private long _lastTick = HighResTimer.GetCurrentTick();
     private bool _disposed;
 
+    #region events
+
     /// <summary>
     /// Occurs when the composite is being disposed.
     /// </summary>
     public event EventHandler<IDirectDrawable>? Disposing;
+
+    #endregion events
+
+    #region constructors
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DirectComposite"/> class.
@@ -54,15 +60,12 @@ public class DirectComposite : IDirectCompositeChild
     /// <param name="mode">The coordinate mode used by the composite and all of its children.</param>
     /// <param name="anchor">The composite anchor, in mode-appropriate pixels.</param>
     /// <param name="nickname">An optional diagnostic nickname.</param>
-    public DirectComposite(
-        RenderSurfaceHostBase renderSurfaceHost,
-        DirectDrawingMode mode,
-        PointF anchor = default,
-        string? nickname = null)
+    public DirectComposite(RenderSurfaceHostBase renderSurfaceHost,
+                           DirectDrawingMode mode,
+                           PointF anchor = default,
+                           string? nickname = null)
     {
-        RenderSurfaceHost =
-            renderSurfaceHost ??
-            throw new ArgumentNullException(nameof(renderSurfaceHost));
+        RenderSurfaceHost = renderSurfaceHost ?? throw new ArgumentNullException(nameof(renderSurfaceHost));
 
         Mode = mode;
         _anchor = anchor;
@@ -70,12 +73,14 @@ public class DirectComposite : IDirectCompositeChild
 
         _readOnlyChildren = new ReadOnlyCollection<IDirectCompositeChild>(_children);
 
-        Movement = new MovementController(
-            this,
-            MovementState.ForPixel());
+        Movement = new MovementController(this, MovementState.ForPixel());
 
         DirectDrawingManager.Instance.AddOrReplace(this);
     }
+
+    #endregion constructors
+
+    #region public properties
 
     /// <summary>
     /// Gets the unique identifier of the composite.
@@ -118,6 +123,9 @@ public class DirectComposite : IDirectCompositeChild
     /// <summary>
     /// Gets the children owned by the composite.
     /// </summary>
+    /// <remarks>
+    /// Implements <see cref="IDirectCompositeContainer.Children"/>.
+    /// </remarks>
     public ReadOnlyCollection<IDirectCompositeChild> Children => _readOnlyChildren;
 
     /// <summary>
@@ -155,14 +163,16 @@ public class DirectComposite : IDirectCompositeChild
     /// <summary>
     /// Gets the union of all visible descendants' screen-space bounds.
     /// </summary>
-    public Rectangle ScreenBounds =>
-        GetBounds(static child => child.ScreenBounds);
+    public Rectangle ScreenBounds => GetBounds(static child => child.ScreenBounds);
 
     /// <summary>
     /// Gets the union of all visible descendants' world-space bounds.
     /// </summary>
-    public Rectangle WorldBounds =>
-        GetBounds(static child => child.WorldBounds);
+    public Rectangle WorldBounds => GetBounds(static child => child.WorldBounds);
+    
+    #endregion public properties
+
+    #region public methods
 
     /// <summary>
     /// Gets the current composite anchor.
@@ -193,11 +203,7 @@ public class DirectComposite : IDirectCompositeChild
 
         foreach (IDirectCompositeChild child in _children)
         {
-            Vector2 offset =
-                _localOffsetPx.TryGetValue(child, out Vector2 value)
-                    ? value
-                    : Vector2.Zero;
-
+            Vector2 offset = _localOffsetPx.TryGetValue(child, out Vector2 value) ? value : Vector2.Zero;
             child.SetPosition(anchor + offset);
         }
 
@@ -224,10 +230,9 @@ public class DirectComposite : IDirectCompositeChild
     /// <exception cref="InvalidOperationException">
     /// Thrown when the child already has another parent or would create a cycle.
     /// </exception>
-    public DirectComposite Add(
-        IDirectCompositeChild child,
-        bool keepCurrentOffset = true,
-        Vector2? explicitLocalOffsetPx = null)
+    public virtual DirectComposite Add(IDirectCompositeChild child,
+                                       bool keepCurrentOffset = true,
+                                       Vector2? explicitLocalOffsetPx = null)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentNullException.ThrowIfNull(child);
@@ -239,9 +244,7 @@ public class DirectComposite : IDirectCompositeChild
         ValidateParentRelationship(child);
         ValidateAndAssignTarget(child);
 
-        Vector2 offset = keepCurrentOffset
-            ? child.GetPosition() - new Vector2(_anchor.X, _anchor.Y)
-            : explicitLocalOffsetPx ?? Vector2.Zero;
+        Vector2 offset = keepCurrentOffset ? child.GetPosition() - new Vector2(_anchor.X, _anchor.Y) : explicitLocalOffsetPx ?? Vector2.Zero;
 
         RegisterParent(child);
 
@@ -251,8 +254,9 @@ public class DirectComposite : IDirectCompositeChild
             _localOffsetPx[child] = offset;
             child.Disposing += OnChildDisposing;
 
-            child.SetPosition(
-                new Vector2(_anchor.X, _anchor.Y) + offset);
+            child.SetPosition(new Vector2(_anchor.X, _anchor.Y) + offset);
+
+            OnChildAdded(child);
         }
         catch
         {
@@ -272,7 +276,7 @@ public class DirectComposite : IDirectCompositeChild
     /// </summary>
     /// <param name="child">The child to detach.</param>
     /// <returns>The current composite.</returns>
-    public DirectComposite Remove(IDirectCompositeChild child)
+    public virtual DirectComposite Remove(IDirectCompositeChild child)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentNullException.ThrowIfNull(child);
@@ -285,6 +289,8 @@ public class DirectComposite : IDirectCompositeChild
         UnregisterParent(child);
         ResetTargetWhenEmpty();
 
+        OnChildRemoved(child);
+
         return this;
     }
 
@@ -292,11 +298,13 @@ public class DirectComposite : IDirectCompositeChild
     /// Removes every child without disposing them.
     /// </summary>
     /// <returns>The current composite.</returns>
-    public DirectComposite Clear()
+    public virtual DirectComposite Clear()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        foreach (IDirectCompositeChild child in _children)
+        IDirectCompositeChild[] children = [.. _children];
+
+        foreach (IDirectCompositeChild child in children)
         {
             child.Disposing -= OnChildDisposing;
             UnregisterParent(child);
@@ -305,6 +313,9 @@ public class DirectComposite : IDirectCompositeChild
         _children.Clear();
         _localOffsetPx.Clear();
         ResetTargetWhenEmpty();
+
+        foreach (IDirectCompositeChild child in children)
+            OnChildRemoved(child);
 
         return this;
     }
@@ -315,9 +326,8 @@ public class DirectComposite : IDirectCompositeChild
     /// <param name="child">The child whose offset should change.</param>
     /// <param name="newLocalOffsetPx">The new offset from the composite anchor.</param>
     /// <returns>The current composite.</returns>
-    public DirectComposite SetLocalOffset(
-        IDirectCompositeChild child,
-        Vector2 newLocalOffsetPx)
+    public DirectComposite SetLocalOffset(IDirectCompositeChild child,
+                                          Vector2 newLocalOffsetPx)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentNullException.ThrowIfNull(child);
@@ -327,9 +337,7 @@ public class DirectComposite : IDirectCompositeChild
 
         _localOffsetPx[child] = newLocalOffsetPx;
 
-        child.SetPosition(
-            new Vector2(_anchor.X, _anchor.Y) +
-            newLocalOffsetPx);
+        child.SetPosition(new Vector2(_anchor.X, _anchor.Y) + newLocalOffsetPx);
 
         return this;
     }
@@ -377,9 +385,7 @@ public class DirectComposite : IDirectCompositeChild
     /// <param name="targetOpacity">The target opacity.</param>
     /// <param name="durationSec">The animation duration in seconds.</param>
     /// <returns>The current composite.</returns>
-    public DirectComposite FadeTo(
-        float targetOpacity,
-        float durationSec)
+    public DirectComposite FadeTo(float targetOpacity, float durationSec)
     {
         foreach (IDirectCompositeChild child in _children)
             child.FadeTo(targetOpacity, durationSec);
@@ -392,16 +398,14 @@ public class DirectComposite : IDirectCompositeChild
     /// </summary>
     /// <param name="durationSec">The animation duration in seconds.</param>
     /// <returns>The current composite.</returns>
-    public DirectComposite FadeIn(float durationSec) =>
-        FadeTo(1f, durationSec);
+    public DirectComposite FadeIn(float durationSec) => FadeTo(1f, durationSec);
 
     /// <summary>
     /// Fades every descendant to zero opacity.
     /// </summary>
     /// <param name="durationSec">The animation duration in seconds.</param>
     /// <returns>The current composite.</returns>
-    public DirectComposite FadeOut(float durationSec) =>
-        FadeTo(0f, durationSec);
+    public DirectComposite FadeOut(float durationSec) => FadeTo(0f, durationSec);
 
     /// <summary>
     /// Gets the union of all visible descendants as projected through a view.
@@ -412,8 +416,7 @@ public class DirectComposite : IDirectCompositeChild
     {
         ArgumentNullException.ThrowIfNull(view);
 
-        if (Mode == DirectDrawingMode.View &&
-            !ReferenceEquals(View, view))
+        if (Mode == DirectDrawingMode.View && !ReferenceEquals(View, view))
         {
             return RectangleF.Empty;
         }
@@ -428,8 +431,7 @@ public class DirectComposite : IDirectCompositeChild
             if (!child.Visible)
                 continue;
 
-            RectangleF bounds =
-                child.GetDrawLocationScreen(view);
+            RectangleF bounds = child.GetDrawLocationScreen(view);
 
             if (bounds.IsEmpty)
                 continue;
@@ -453,40 +455,18 @@ public class DirectComposite : IDirectCompositeChild
     /// <summary>
     /// Performs no direct rendering because descendants render independently.
     /// </summary>
-    public void Draw(
-        BackbufferBase backbuffer,
-        RectangleF destRectScreen)
-    {
-    }
-
-    void IDirectCompositeChild.SetIsVisible(bool visible)
-    {
-        SetIsVisible(visible);
-    }
-
-    void IDirectCompositeChild.SetZOrder(int zOrder)
-    {
-        SetZOrder(zOrder);
-    }
-
-    void IDirectCompositeChild.SetOpacity(float opacity)
-    {
-        SetOpacity(opacity);
-    }
-
-    void IDirectCompositeChild.FadeTo(
-        float targetOpacity,
-        float durationSec)
-    {
-        FadeTo(
-            targetOpacity,
-            durationSec);
-    }
+    /// <param name="backbuffer">The backbuffer to draw to (not used).</param>
+    /// <param name="destRectScreen">The destination rectangle in screen coordinates (not used).</param>
+    public void Draw(BackbufferBase backbuffer, RectangleF destRectScreen) { }
 
     /// <summary>
     /// Advances composite movement.
     /// </summary>
     /// <param name="tick">The current engine tick.</param>
+    /// <remarks>
+    /// This method uses the tick to calculate elapsed time and advance the movement controller.
+    /// If the tick is less than or equal to the last processed tick, no update occurs.
+    /// </remarks>
     public void Update(long tick)
     {
         if (_disposed || tick <= _lastTick)
@@ -527,8 +507,70 @@ public class DirectComposite : IDirectCompositeChild
         Disposing = null;
     }
 
-    private Rectangle GetBounds(
-        Func<IDirectCompositeChild, Rectangle> selector)
+    #endregion public methods
+
+    #region IDirectCompositeChild explicit interface implementations
+
+    void IDirectCompositeChild.SetIsVisible(bool visible) => SetIsVisible(visible);
+
+    void IDirectCompositeChild.SetZOrder(int zOrder) => SetZOrder(zOrder);
+
+    void IDirectCompositeChild.SetOpacity(float opacity) => SetOpacity(opacity);
+
+    void IDirectCompositeChild.FadeTo(float targetOpacity, float durationSec) => FadeTo(targetOpacity, durationSec);
+
+    #endregion IDirectCompositeChild explicit interface implementations
+
+    #region IDirectCompositeContainer explicit interface implementations
+
+    IReadOnlyCollection<IDirectCompositeChild> IDirectCompositeContainer.Children => Children;
+
+    IDirectCompositeContainer IDirectCompositeContainer.Add(IDirectCompositeChild child, bool keepCurrentOffset, Vector2? explicitLocalOffsetPx)
+    {
+        return Add(child, keepCurrentOffset, explicitLocalOffsetPx);
+    }
+
+    IDirectCompositeContainer IDirectCompositeContainer.Remove(IDirectCompositeChild child)
+    {
+        return Remove(child);
+    }
+
+    IDirectCompositeContainer IDirectCompositeContainer.Clear()
+    {
+        return Clear();
+    }
+
+    #endregion IDirectCompositeContainer explicit interface implementations
+
+    #region protected hooks
+
+    /// <summary>
+    /// Called after a child has been successfully added.
+    /// </summary>
+    /// <param name="child">The child that was added.</param>
+    /// <remarks>
+    /// Overrides should perform only non-throwing bookkeeping. Derived types that
+    /// need additional validation should override <see cref="Add"/>, perform that
+    /// validation before calling the base implementation, and then allow this
+    /// callback to perform the resulting bookkeeping.
+    /// </remarks>
+    protected virtual void OnChildAdded(IDirectCompositeChild child)
+    {
+    }
+
+    /// <summary>
+    /// Called after a child has been removed from the composite.
+    /// </summary>
+    /// <param name="child">The child that was removed.</param>
+    protected virtual void OnChildRemoved(IDirectCompositeChild child)
+    {
+    }
+
+    #endregion protected hooks
+
+    #region private methods
+
+    private Rectangle GetBounds(Func<IDirectCompositeChild, Rectangle> selector)
     {
         float minX = float.MaxValue;
         float minY = float.MaxValue;
@@ -563,21 +605,14 @@ public class DirectComposite : IDirectCompositeChild
 
     private void ValidateChildIdentity(IDirectCompositeChild child)
     {
-        if (!ReferenceEquals(
-                child.RenderSurfaceHost,
-                RenderSurfaceHost))
+        if (!ReferenceEquals(child.RenderSurfaceHost, RenderSurfaceHost))
         {
-            throw new ArgumentException(
-                "The child must belong to the same RenderSurfaceHost as the composite.",
-                nameof(child));
+            throw new ArgumentException("The child must belong to the same RenderSurfaceHost as the composite.", nameof(child));
         }
 
         if (child.Mode != Mode)
         {
-            throw new ArgumentException(
-                $"The child drawing mode '{child.Mode}' does not match " +
-                $"the composite drawing mode '{Mode}'.",
-                nameof(child));
+            throw new ArgumentException($"The child drawing mode '{child.Mode}' does not match the composite drawing mode '{Mode}'.", nameof(child));
         }
     }
 
@@ -585,23 +620,15 @@ public class DirectComposite : IDirectCompositeChild
     {
         if (Mode == DirectDrawingMode.SceneLayer)
         {
-            SceneLayer childLayer =
-                child.SceneLayer ??
-                throw new ArgumentException(
-                    "A scene-layer child must reference a SceneLayer.",
-                    nameof(child));
+            SceneLayer childLayer = child.SceneLayer ?? throw new ArgumentException("A scene-layer child must reference a SceneLayer.", nameof(child));
 
             if (SceneLayer is null)
             {
                 SceneLayer = childLayer;
             }
-            else if (!ReferenceEquals(
-                         SceneLayer,
-                         childLayer))
+            else if (!ReferenceEquals(SceneLayer, childLayer))
             {
-                throw new ArgumentException(
-                    "All scene-layer children in a composite must reference the same SceneLayer.",
-                    nameof(child));
+                throw new ArgumentException("All scene-layer children in a composite must reference the same SceneLayer.", nameof(child));
             }
 
             return;
@@ -617,9 +644,7 @@ public class DirectComposite : IDirectCompositeChild
                     nameof(child));
             }
 
-            throw new ArgumentException(
-                "A view child must reference a View.",
-                nameof(child));
+            throw new ArgumentException("A view child must reference a View.", nameof(child));
         }
 
         View childView = child.View;
@@ -627,13 +652,9 @@ public class DirectComposite : IDirectCompositeChild
         {
             View = childView;
         }
-        else if (!ReferenceEquals(
-                     View,
-                     childView))
+        else if (!ReferenceEquals(View, childView))
         {
-            throw new ArgumentException(
-                "All view children in a composite must reference the same View.",
-                nameof(child));
+            throw new ArgumentException("All view children in a composite must reference the same View.", nameof(child));
         }
     }
 
@@ -641,12 +662,9 @@ public class DirectComposite : IDirectCompositeChild
     {
         lock (_parentSyncRoot)
         {
-            if (_parents.TryGetValue(
-                    child,
-                    out DirectComposite? existingParent))
+            if (_parents.TryGetValue(child, out DirectComposite? existingParent))
             {
-                throw new InvalidOperationException(
-                    $"The child already belongs to composite '{existingParent.Nickname}'.");
+                throw new InvalidOperationException($"The child already belongs to composite '{existingParent.Nickname}'.");
             }
 
             if (child is not DirectComposite childComposite)
@@ -656,17 +674,12 @@ public class DirectComposite : IDirectCompositeChild
 
             while (ancestor is not null)
             {
-                if (ReferenceEquals(
-                        ancestor,
-                        childComposite))
+                if (ReferenceEquals(ancestor, childComposite))
                 {
-                    throw new InvalidOperationException(
-                        "Adding the child would create a recursive composite cycle.");
+                    throw new InvalidOperationException("Adding the child would create a recursive composite cycle.");
                 }
 
-                _parents.TryGetValue(
-                    ancestor,
-                    out ancestor);
+                _parents.TryGetValue(ancestor, out ancestor);
             }
         }
     }
@@ -681,9 +694,7 @@ public class DirectComposite : IDirectCompositeChild
     {
         lock (_parentSyncRoot)
         {
-            if (_parents.TryGetValue(
-                    child,
-                    out DirectComposite? parent) &&
+            if (_parents.TryGetValue(child, out DirectComposite? parent) &&
                 ReferenceEquals(parent, this))
             {
                 _parents.Remove(child);
@@ -700,18 +711,22 @@ public class DirectComposite : IDirectCompositeChild
         View = null;
     }
 
-    private void OnChildDisposing(
-        object? sender,
-        IDirectDrawable drawing)
+    private void OnChildDisposing(object? sender, IDirectDrawable drawing)
     {
         if (drawing is not IDirectCompositeChild child)
             return;
 
         child.Disposing -= OnChildDisposing;
-        _children.Remove(child);
+
+        if (!_children.Remove(child))
+            return;
+
         _localOffsetPx.Remove(child);
         UnregisterParent(child);
         ResetTargetWhenEmpty();
+
+        OnChildRemoved(child);
     }
 
+    #endregion private methods
 }

--- a/Gondwana/Drawing/Direct/IDirectCompositeChild.cs
+++ b/Gondwana/Drawing/Direct/IDirectCompositeChild.cs
@@ -56,7 +56,5 @@ public interface IDirectCompositeChild : IDirectDrawable, IMovable
     /// </summary>
     /// <param name="targetOpacity">The target opacity in the range 0 through 1.</param>
     /// <param name="durationSec">The fade duration in seconds.</param>
-    void FadeTo(
-        float targetOpacity,
-        float durationSec);
+    void FadeTo(float targetOpacity, float durationSec);
 }

--- a/Gondwana/Drawing/Direct/IDirectCompositeContainer.cs
+++ b/Gondwana/Drawing/Direct/IDirectCompositeContainer.cs
@@ -1,0 +1,36 @@
+﻿using System.Numerics;
+
+namespace Gondwana.Drawing.Direct;
+
+/// <summary>
+/// Defines a container that can hold and manage a collection of direct composite children.
+/// </summary>
+public interface IDirectCompositeContainer
+{
+    /// <summary>
+    /// Gets the read-only collection of child elements in this container.
+    /// </summary>
+    IReadOnlyCollection<IDirectCompositeChild> Children { get; }
+
+    /// <summary>
+    /// Adds a child element to this container.
+    /// </summary>
+    /// <param name="child">The child element to add to the container.</param>
+    /// <param name="keepCurrentOffset">If true, maintains the child's current offset; otherwise, resets the offset.</param>
+    /// <param name="explicitLocalOffsetPx">Optional explicit local offset in pixels to apply to the child.</param>
+    /// <returns>The current container instance for method chaining.</returns>
+    IDirectCompositeContainer Add(IDirectCompositeChild child, bool keepCurrentOffset = true, Vector2? explicitLocalOffsetPx = null);
+
+    /// <summary>
+    /// Removes a child element from this container.
+    /// </summary>
+    /// <param name="child">The child element to remove from the container.</param>
+    /// <returns>The current container instance for method chaining.</returns>
+    IDirectCompositeContainer Remove(IDirectCompositeChild child);
+
+    /// <summary>
+    /// Removes all child elements from this container.
+    /// </summary>
+    /// <returns>The current container instance for method chaining.</returns>
+    IDirectCompositeContainer Clear();
+}

--- a/Testing/Gondwana.Tests/Widgets/ContainerWidgetTests.cs
+++ b/Testing/Gondwana.Tests/Widgets/ContainerWidgetTests.cs
@@ -244,7 +244,7 @@ public sealed class ContainerWidgetTests
             WidgetBase widget,
             Vector2 offset)
         {
-            AddChild(
+            Add(
                 widget,
                 offset);
         }


### PR DESCRIPTION
- Added a new `HyperlinkWidget` control with external URI launching support via `IExternalUriLauncher`.
- Refactored `ContainerWidget` for improved child composition/layout behavior used by widget controls.
- Updated About dialog to use hyperlink UI, improving discoverability of external links.
- Reworked direct composite container/child interfaces and implementation to align rendering with new widget model.