### PR TITLE
fix(rendering): fix zoom calculations and movement timing

### DIFF
--- a/Gondwana/Drawing/Direct/DirectDrawingMovableBase.cs
+++ b/Gondwana/Drawing/Direct/DirectDrawingMovableBase.cs
@@ -91,30 +91,47 @@ public abstract class DirectDrawingMovableBase : DirectDrawingBase, IDirectCompo
     }
 
     /// <summary>
-    /// Gets the movement controller that manages physics-based position, velocity, and forces for this direct drawing.
+    /// Gets the movement controller responsible for changing this direct drawing's
+    /// position over time.
     /// </summary>
     /// <value>
-    /// A <see cref="MovementController"/> instance providing access to movement state, velocity, acceleration,
-    /// friction, and other physics properties.
+    /// A <see cref="MovementController"/> configured to move this drawing in
+    /// <see cref="MovementSpace.Pixel"/>.
     /// </value>
     /// <remarks>
     /// <para>
-    /// Use the movement controller to:
+    /// The controller supports follow, scripted, and integrated movement:
+    /// </para>
     /// <list type="bullet">
-    /// <item><description>Apply forces and impulses (e.g., <c>Movement.ApplyForce()</c>, <c>Movement.ApplyImpulse()</c>).</description></item>
-    /// <item><description>Set or query velocity (e.g., <c>Movement.Velocity</c>).</description></item>
-    /// <item><description>Configure friction, mass, and other physical properties.</description></item>
-    /// <item><description>Enable or disable movement integration.</description></item>
+    /// <item>
+    /// <description>
+    /// Follow movement continuously tracks a live pixel-space or grid-space target.
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <description>
+    /// Scripted movement performs authored operations such as
+    /// <c>MoveTo</c>, <c>MoveBy</c>, and <c>MoveToward</c>.
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <description>
+    /// Integrated movement advances velocity, acceleration, maximum-speed limits,
+    /// and linear damping over time.
+    /// </description>
+    /// </item>
     /// </list>
+    /// <para>
+    /// Movement coordinates represent the drawing's upper-left position. For
+    /// <see cref="DirectDrawingMode.SceneLayer"/> drawings, they are world pixels.
+    /// For <see cref="DirectDrawingMode.View"/> drawings, they are absolute
+    /// screen pixels.
     /// </para>
     /// <para>
-    /// The controller is automatically integrated each frame by <see cref="Update"/> using a fixed timestep
-    /// (240 Hz). Position changes from the controller are synchronized to the drawing's bounds, triggering
-    /// dirty-rectangle updates as needed.
-    /// </para>
-    /// <para>
-    /// The controller operates in pixel space (<see cref="MovementSpace.Pixel"/>), matching the coordinate
-    /// system used by the drawing's bounds (either world or screen coordinates depending on the mode).
+    /// The controller is advanced automatically by <see cref="Update(long)"/>
+    /// once per engine update using the actual elapsed duration. Game code should
+    /// configure movement through this property rather than calling
+    /// <c>AdvanceMovement</c> directly.
     /// </para>
     /// </remarks>
     public MovementController Movement { get; }

--- a/Gondwana/Drawing/Direct/DirectDrawingMovableBase.cs
+++ b/Gondwana/Drawing/Direct/DirectDrawingMovableBase.cs
@@ -44,10 +44,6 @@ namespace Gondwana.Drawing.Direct;
 /// </remarks>
 public abstract class DirectDrawingMovableBase : DirectDrawingBase, IDirectCompositeChild
 {
-    // update timing for fixed-step physics
-    private float _accum;
-    private const float _fixedDt = 1f / 240f;
-    private const int _maxSubsteps = 8;
     private Vector2 _posPx;
 
     /// <summary>
@@ -237,34 +233,20 @@ public abstract class DirectDrawingMovableBase : DirectDrawingBase, IDirectCompo
     }
 
     /// <summary>
-    /// Performs per-frame update logic, including fixed-timestep physics integration for movement.
+    /// Advances this direct drawing's movement using the elapsed time since
+    /// its previous update, then performs the standard direct-drawing update logic.
     /// </summary>
-    /// <param name="tick">The current engine tick value from <see cref="HighResTimer"/>.</param>
+    /// <param name="tick">
+    /// The current engine tick value supplied by the direct-drawing update cycle.
+    /// </param>
     /// <remarks>
     /// <para>
-    /// This method overrides <see cref="DirectDrawingBase.Update"/> to add physics integration via
-    /// the <see cref="Movement"/> controller. It uses a fixed-timestep accumulator pattern to ensure
-    /// stable, deterministic movement regardless of frame rate variations.
+    /// Movement is advanced once per engine update using the actual elapsed duration
+    /// calculated from <see cref="_lastTick"/> and <paramref name="tick"/>.
     /// </para>
     /// <para>
-    /// The update process works as follows:
-    /// <list type="number">
-    /// <item><description>Calculates the elapsed time since the last frame, clamping large deltas (>66ms) to prevent instability during frame rate drops, alt-tab, or debugger pauses.</description></item>
-    /// <item><description>Accumulates the frame delta time and subdivides it into fixed timesteps of ~4.16ms (240 Hz).</description></item>
-    /// <item><description>Integrates movement physics at the fixed timestep for up to 8 substeps per frame to prevent spiral of death.</description></item>
-    /// <item><description>If the maximum substep limit is reached, discards remaining accumulated time to maintain real-time responsiveness.</description></item>
-    /// <item><description>Calls <c>base.Update(tick)</c> to perform fade and reveal animations from <see cref="DirectDrawingBase"/>.</description></item>
-    /// </list>
-    /// </para>
-    /// <para>
-    /// The fixed timestep ensures that physics simulations produce consistent, reproducible results across
-    /// different hardware and frame rates. The substep limit (8 steps) prevents performance degradation
-    /// when the frame rate drops significantly, trading some physics accuracy for real-time responsiveness.
-    /// </para>
-    /// <para>
-    /// Override this method in derived classes to add custom per-frame logic (such as AI updates or
-    /// animation state changes). Always call <c>base.Update(tick)</c> to preserve movement integration
-    /// and fade/reveal animations.
+    /// The base implementation is called afterward to advance inherited behavior,
+    /// including fade and reveal animations, and to record the current tick.
     /// </para>
     /// </remarks>
     public override void Update(long tick)
@@ -272,26 +254,10 @@ public abstract class DirectDrawingMovableBase : DirectDrawingBase, IDirectCompo
         if (tick <= _lastTick)
             return;
 
-        // 1) clamp giant stalls (alt-tab, debugger break, GC, etc.)
-        const float MaxFrameDt = 1f / 15f; // ~66ms
-        float dt = MathF.Min(HighResTimer.GetDuration(_lastTick, tick), MaxFrameDt);
+        float dt =
+            HighResTimer.GetDuration(_lastTick, tick);
 
-        // 2) accumulate time
-        _accum += dt;
-
-        int steps = 0;
-        while (_accum >= _fixedDt && steps < _maxSubsteps)
-        {
-            // Always integrate at the fixed step (not dt!)
-            Movement.AdvanceMovement(_fixedDt);
-
-            _accum -= _fixedDt;
-            steps++;
-        }
-
-        // 3) if we hit the cap, drop remainder so we don't spiral
-        if (steps == _maxSubsteps)
-            _accum = 0f;
+        Movement.AdvanceMovement(dt);
 
         base.Update(tick);
     }

--- a/Gondwana/Drawing/Direct/DirectDrawingMovableBase.cs
+++ b/Gondwana/Drawing/Direct/DirectDrawingMovableBase.cs
@@ -240,9 +240,7 @@ public abstract class DirectDrawingMovableBase : DirectDrawingBase, IDirectCompo
         Opacity = opacity;
     }
 
-    void IDirectCompositeChild.FadeTo(
-        float targetOpacity,
-        float durationSec)
+    void IDirectCompositeChild.FadeTo(float targetOpacity, float durationSec)
     {
         base.FadeTo(
             targetOpacity,

--- a/Gondwana/Drawing/Direct/IDirectCompositeChild.cs
+++ b/Gondwana/Drawing/Direct/IDirectCompositeChild.cs
@@ -56,7 +56,5 @@ public interface IDirectCompositeChild : IDirectDrawable, IMovable
     /// </summary>
     /// <param name="targetOpacity">The target opacity in the range 0 through 1.</param>
     /// <param name="durationSec">The fade duration in seconds.</param>
-    void FadeTo(
-        float targetOpacity,
-        float durationSec);
+    void FadeTo(float targetOpacity, float durationSec);
 }

--- a/Gondwana/Drawing/Direct/TextBlock.cs
+++ b/Gondwana/Drawing/Direct/TextBlock.cs
@@ -677,19 +677,7 @@ public class TextBlock : DirectDrawingMovableBase
         var canvas = backbuffer.Canvas;
         var rect = destRectScreen.ToSKRect();
 
-        float zoom;
-
-        if (Mode == DirectDrawingMode.SceneLayer)
-        {
-            // SceneLayer-mode has View == null by design; use the ambient render context.
-            var contextZoom = RenderContext.Current?.ViewportZoom ?? 1f;
-            zoom = (contextZoom > 0f) ? contextZoom : 1f;
-        }
-        else
-        {
-            // View-mode is screen/UI; do not compensate for camera zoom.
-            zoom = 1f;
-        }
+        float zoom = ResolveTextScale(Mode, RenderContext.Current?.ViewportZoom ?? 1f);
 
         // Scale "pixel-like" adornments with zoom so text behaves like other world-space drawables.
         float hPad = HorizontalPadding * zoom;

--- a/Gondwana/Drawing/Direct/TextBlock.cs
+++ b/Gondwana/Drawing/Direct/TextBlock.cs
@@ -683,9 +683,7 @@ public class TextBlock : DirectDrawingMovableBase
         {
             // SceneLayer-mode has View == null by design; use the ambient render context.
             var contextZoom = RenderContext.Current?.ViewportZoom ?? 1f;
-            zoom = (contextZoom > 0f)
-                ? (1f / contextZoom)
-                : 1f;
+            zoom = (contextZoom > 0f) ? contextZoom : 1f;
         }
         else
         {
@@ -867,6 +865,14 @@ public class TextBlock : DirectDrawingMovableBase
         }
 
         canvas.Restore();
+    }
+
+    internal static float ResolveTextScale(DirectDrawingMode mode, float viewportZoom)
+    {
+        if (mode != DirectDrawingMode.SceneLayer)
+            return 1f;
+
+        return viewportZoom > 0f ? viewportZoom : 1f;
     }
 
     private void RebuildLayout(SKPaint paint, float maxWidth)

--- a/Gondwana/Rendering/Views/Camera.cs
+++ b/Gondwana/Rendering/Views/Camera.cs
@@ -325,6 +325,15 @@ public sealed class Camera
     }
 
     /// <summary>
+    /// Cancels an active explicit pan without changing the configured follow target.
+    /// </summary>
+    internal void CancelPan()
+    {
+        _panTargetUpperLeftPx = null;
+        _panLerpPerSecond = 0f;
+    }
+
+    /// <summary>
     /// Configures the camera to follow a dynamically supplied world-space
     /// target position. Each update, the supplier is called to get the
     /// desired target "point of interest" in world pixels (typically a

--- a/Gondwana/Rendering/Views/View.cs
+++ b/Gondwana/Rendering/Views/View.cs
@@ -1,7 +1,5 @@
 ﻿using System.Drawing;
-using Gondwana.Logging;
 using Gondwana.Scenes;
-using Microsoft.Extensions.Logging;
 
 namespace Gondwana.Rendering.Views;
 
@@ -104,10 +102,10 @@ public sealed class View
         float localX = screenPoint.X - offsetX;
         float localY = screenPoint.Y - offsetY;
 
-        // screen = offset + (world - camera*p) / zoom
-        // camera = (world - local*zoom) / p
-        float camTargetX = (worldUnderCursor.X - localX * targetZoom) / parallax;
-        float camTargetY = (worldUnderCursor.Y - localY * targetZoom) / parallax;
+        // screen = offset + (world - camera*p) * zoom
+        // camera = (world - local/zoom) / p
+        float camTargetX = (worldUnderCursor.X - localX / targetZoom) / parallax;
+        float camTargetY = (worldUnderCursor.Y - localY / targetZoom) / parallax;
 
         var cameraTargetUL = new PointF(camTargetX, camTargetY);
 
@@ -141,7 +139,7 @@ public sealed class View
     /// </returns>
     /// <remarks>
     /// The transformation formula is:
-    /// <code>world = camera * parallax + (screen - offset) * zoom</code>
+    /// <code>world = camera * parallax + (screen - offset) / zoom</code>
     /// This is commonly used for mouse picking and screen-to-world raycasting.
     /// </remarks>
     public PointF ScreenPxToWorldPx(SceneLayer layer, PointF screenPx)
@@ -152,10 +150,10 @@ public sealed class View
         float parallax = layer.Parallax;
 
         float worldX = Camera.PositionPx.X * parallax
-                     + (screenPx.X - offsetX) * zoom;
+                     + (screenPx.X - offsetX) / zoom;
 
         float worldY = Camera.PositionPx.Y * parallax
-                     + (screenPx.Y - offsetY) * zoom;
+                     + (screenPx.Y - offsetY) / zoom;
 
         return new PointF(worldX, worldY);
     }
@@ -176,7 +174,7 @@ public sealed class View
     /// </returns>
     /// <remarks>
     /// The transformation formula is:
-    /// <code>screen = offset + (world - camera * parallax) / zoom</code>
+    /// <code>screen = offset + (world - camera * parallax) * zoom</code>
     /// This is commonly used for rendering world objects to screen coordinates
     /// and for UI elements that track world positions.
     /// </remarks>
@@ -187,8 +185,8 @@ public sealed class View
         float offsetY = Viewport.TargetRectPx.Top + Viewport.ScreenOffsetPx.Y;
         float parallax = layer.Parallax;
 
-        float screenX = offsetX + (worldPx.X - Camera.PositionPx.X * parallax) / zoom;
-        float screenY = offsetY + (worldPx.Y - Camera.PositionPx.Y * parallax) / zoom;
+        float screenX = offsetX + (worldPx.X - Camera.PositionPx.X * parallax) * zoom;
+        float screenY = offsetY + (worldPx.Y - Camera.PositionPx.Y * parallax) * zoom;
 
         return new PointF(screenX, screenY);
     }
@@ -212,7 +210,7 @@ public sealed class View
     /// for this View, using the specified layer's parallax factor.
     ///
     /// Matches the render path:
-    ///   screen = offset + (world - camera * parallax) / zoom
+    ///   screen = offset + (world - camera * parallax) * zoom
     /// </summary>
     /// <param name="layer">Scene layer whose parallax should be applied.</param>
     /// <param name="worldRect">World-space rectangle (in pixels).</param>
@@ -223,21 +221,20 @@ public sealed class View
             throw new ArgumentNullException(nameof(layer));
 
         float zoom = Viewport.Zoom <= 0f ? 1f : Viewport.Zoom;
-        float inverseZoom = 1f / zoom;
 
         float offsetX = Viewport.TargetRectPx.Left + Viewport.ScreenOffsetPx.X;
         float offsetY = Viewport.TargetRectPx.Top + Viewport.ScreenOffsetPx.Y;
 
         float parallax = layer.Parallax;
 
-        // screen = offset + (world - camera * p) / zoom
+        // screen = offset + (world - camera * p) * zoom
         float localLeft = worldRect.Left - Camera.PositionPx.X * parallax;
         float localTop = worldRect.Top - Camera.PositionPx.Y * parallax;
 
-        float scaledLeft = localLeft * inverseZoom;
-        float scaledTop = localTop * inverseZoom;
-        float scaledWidth = worldRect.Width * inverseZoom;
-        float scaledHeight = worldRect.Height * inverseZoom;
+        float scaledLeft = localLeft * zoom;
+        float scaledTop = localTop * zoom;
+        float scaledWidth = worldRect.Width * zoom;
+        float scaledHeight = worldRect.Height * zoom;
 
         float screenLeft = offsetX + scaledLeft;
         float screenTop = offsetY + scaledTop;
@@ -251,7 +248,7 @@ public sealed class View
     /// and the layer's parallax factor.
     ///
     /// Inverse of:
-    ///     screen = offset + (world - camera * p) / zoom
+    ///     screen = offset + (world - camera * p) * zoom
     /// </summary>
     public RectangleF ScreenRectToWorldRect(SceneLayer layer, RectangleF screenRect)
     {
@@ -269,12 +266,12 @@ public sealed class View
         float localLeft = screenRect.Left - offsetX;
         float localTop = screenRect.Top - offsetY;
 
-        // world = camera*parallax + local * zoom
-        float worldLeft = Camera.PositionPx.X * parallax + localLeft * zoom;
-        float worldTop = Camera.PositionPx.Y * parallax + localTop * zoom;
+        // world = camera*parallax + local / zoom
+        float worldLeft = Camera.PositionPx.X * parallax + localLeft / zoom;
+        float worldTop = Camera.PositionPx.Y * parallax + localTop / zoom;
 
-        float worldWidth = screenRect.Width * zoom;
-        float worldHeight = screenRect.Height * zoom;
+        float worldWidth = screenRect.Width / zoom;
+        float worldHeight = screenRect.Height / zoom;
 
         return new RectangleF(worldLeft, worldTop, worldWidth, worldHeight);
     }

--- a/Gondwana/Rendering/Views/View.cs
+++ b/Gondwana/Rendering/Views/View.cs
@@ -1,5 +1,7 @@
 ﻿using System.Drawing;
+using Gondwana.Logging;
 using Gondwana.Scenes;
+using Microsoft.Extensions.Logging;
 
 namespace Gondwana.Rendering.Views;
 
@@ -11,6 +13,10 @@ namespace Gondwana.Rendering.Views;
 /// </summary>
 public sealed class View
 {
+    private SceneLayer? _zoomAnchorLayer;
+    private PointF _zoomAnchorScreenPoint;
+    private PointF _zoomAnchorWorldPoint;
+
     /// <summary>
     /// Gets the unique identifier for this view instance.
     /// </summary>
@@ -63,10 +69,8 @@ public sealed class View
     }
 
     /// <summary>
-    /// Smoothly zooms the view so that a given screen-space point appears to
-    /// zoom in/out around a fixed world position beneath it, similar to
-    /// map-style mouse-wheel zoom. Both the viewport zoom and camera position
-    /// are animated over the specified duration.
+    /// Zooms the view around a screen-space point while keeping the world point
+    /// beneath that location fixed throughout the operation.
     /// </summary>
     /// <param name="layer">
     /// Reference layer whose parallax factor is used for the world-space transform.
@@ -79,21 +83,82 @@ public sealed class View
     /// Desired zoom factor after the animation completes.
     /// </param>
     /// <param name="durationSeconds">
-    /// Approximate duration in seconds for the zoom + pan animation.
-    /// Values &lt;= 0 snap immediately.
+    /// Duration in seconds for the zoom animation. Values &lt;= 0 snap immediately.
     /// </param>
+    /// <remarks>
+    /// During a smooth zoom, the viewport zoom is animated and the camera position
+    /// is recomputed after every intermediate zoom update. This prevents the anchor
+    /// point from drifting while zoom and camera movement are in progress.
+    /// </remarks>
     public void ZoomAroundScreenPoint(SceneLayer layer, PointF screenPoint, float targetZoom, float durationSeconds)
     {
-        if (layer is null)
-            throw new ArgumentNullException(nameof(layer));
+        ArgumentNullException.ThrowIfNull(layer);
 
         targetZoom = Math.Clamp(targetZoom, MinZoom, MaxZoom);
 
-        // World under cursor BEFORE zoom changes
-        var worldUnderCursor = ScreenPxToWorldPx(layer, screenPoint);
+        PointF worldUnderCursor = ScreenPxToWorldPx(layer, screenPoint);
 
-        float offsetX = Viewport.TargetRectPx.Left + Viewport.ScreenOffsetPx.X;
-        float offsetY = Viewport.TargetRectPx.Top + Viewport.ScreenOffsetPx.Y;
+        // Anchored zoom owns camera positioning until the zoom completes. Cancel an
+        // unrelated explicit pan, but leave follow configuration intact so it can
+        // resume on the next update after the anchored zoom finishes.
+        Camera.CancelPan();
+
+        if (durationSeconds <= 0f)
+        {
+            ClearZoomAnchor();
+            Viewport.SnapZoom(targetZoom);
+            SnapCameraToZoomAnchor(layer, screenPoint, worldUnderCursor);
+            return;
+        }
+
+        _zoomAnchorLayer = layer;
+        _zoomAnchorScreenPoint = screenPoint;
+        _zoomAnchorWorldPoint = worldUnderCursor;
+
+        Viewport.ZoomToOverDuration(targetZoom, durationSeconds);
+    }
+
+    /// <summary>
+    /// Advances camera and zoom state for this view.
+    /// </summary>
+    internal void Update(float dtSeconds)
+    {
+        if (_zoomAnchorLayer is { } anchorLayer)
+        {
+            // Update zoom first, then derive the one camera position that keeps
+            // the selected world point at the selected screen point.
+            Viewport.UpdateZoom(dtSeconds);
+            SnapCameraToZoomAnchor(
+                anchorLayer,
+                _zoomAnchorScreenPoint,
+                _zoomAnchorWorldPoint);
+
+            if (!Viewport.IsZoomAnimating)
+                ClearZoomAnchor();
+
+            return;
+        }
+
+        Camera.Update(dtSeconds);
+        Viewport.UpdateZoom(dtSeconds);
+    }
+
+    private void SnapCameraToZoomAnchor(
+        SceneLayer layer,
+        PointF screenPoint,
+        PointF worldPoint)
+    {
+        float zoom = Viewport.Zoom > 0f
+            ? Viewport.Zoom
+            : 1f;
+
+        float offsetX =
+            Viewport.TargetRectPx.Left
+            + Viewport.ScreenOffsetPx.X;
+
+        float offsetY =
+            Viewport.TargetRectPx.Top
+            + Viewport.ScreenOffsetPx.Y;
 
         float parallax = layer.Parallax;
         if (Math.Abs(parallax) < 1e-6f)
@@ -104,21 +169,22 @@ public sealed class View
 
         // screen = offset + (world - camera*p) * zoom
         // camera = (world - local/zoom) / p
-        float camTargetX = (worldUnderCursor.X - localX / targetZoom) / parallax;
-        float camTargetY = (worldUnderCursor.Y - localY / targetZoom) / parallax;
+        float cameraX =
+            (worldPoint.X - localX / zoom)
+            / parallax;
 
-        var cameraTargetUL = new PointF(camTargetX, camTargetY);
+        float cameraY =
+            (worldPoint.Y - localY / zoom)
+            / parallax;
 
-        if (durationSeconds <= 0f)
-        {
-            Viewport.SnapZoom(targetZoom);
-            Camera.SnapTo(cameraTargetUL);
-        }
-        else
-        {
-            Viewport.ZoomToOverDuration(targetZoom, durationSeconds);
-            Camera.PanToOverDuration(cameraTargetUL, durationSeconds);
-        }
+        Camera.SnapTo(new PointF(cameraX, cameraY));
+    }
+
+    private void ClearZoomAnchor()
+    {
+        _zoomAnchorLayer = null;
+        _zoomAnchorScreenPoint = PointF.Empty;
+        _zoomAnchorWorldPoint = PointF.Empty;
     }
 
     #region Coordinate conversion methods

--- a/Gondwana/Rendering/Views/ViewManager.cs
+++ b/Gondwana/Rendering/Views/ViewManager.cs
@@ -271,10 +271,7 @@ public sealed class ViewManager
     internal void UpdateCameras(float dtSeconds)
     {
         foreach (var view in _views)
-        {
-            view.Camera.Update(dtSeconds);
-            view.Viewport.UpdateZoom(dtSeconds);
-        }
+            view.Update(dtSeconds);
     }
 
     internal void BindToScene(Scene scene, bool limitCameraToWorldBoundPx)

--- a/Gondwana/Rendering/Views/Viewport.cs
+++ b/Gondwana/Rendering/Views/Viewport.cs
@@ -13,6 +13,8 @@ public sealed class Viewport
     private float _zoom = 1f;
     private float? _zoomTarget;
     private float _zoomLerpPerSecond;
+    private float? _zoomDurationSeconds;
+    private float _zoomElapsedSeconds;
 
     /// <summary>
     /// Fired whenever <see cref="TargetRectPx"/> changes (viewport resized or moved).
@@ -81,6 +83,9 @@ public sealed class Viewport
     /// <summary>World size visible through this viewport (used for Camera clamping).</summary>
     public SizeF VisibleWorldSizePx => new SizeF(TargetRectPx.Width / Zoom, TargetRectPx.Height / Zoom);
 
+    /// <summary>Gets whether a smooth zoom animation is currently active.</summary>
+    internal bool IsZoomAnimating => _zoomTarget is not null;
+
     #region zoom zoom
 
     /// <summary>
@@ -90,6 +95,8 @@ public sealed class Viewport
     {
         _zoomTarget = null;
         _zoomLerpPerSecond = 0f;
+        _zoomDurationSeconds = null;
+        _zoomElapsedSeconds = 0f;
         Zoom = zoom;
     }
 
@@ -107,11 +114,13 @@ public sealed class Viewport
 
         _zoomTarget = targetZoom;
         _zoomLerpPerSecond = lerpPerSecond;
+        _zoomDurationSeconds = null;
+        _zoomElapsedSeconds = 0f;
     }
 
     /// <summary>
-    /// Smoothly animates the zoom so that it reaches ~99% of the target level
-    /// over approximately the given duration in seconds. Values &lt;= 0 snap.
+    /// Smoothly animates the zoom using exponential easing and snaps exactly to
+    /// the target when the requested duration has elapsed. Values &lt;= 0 snap.
     /// </summary>
     public void ZoomToOverDuration(float targetZoom, float durationSeconds)
     {
@@ -126,6 +135,8 @@ public sealed class Viewport
 
         _zoomTarget = targetZoom;
         _zoomLerpPerSecond = k;
+        _zoomDurationSeconds = durationSeconds;
+        _zoomElapsedSeconds = 0f;
     }
 
     /// <summary>
@@ -138,20 +149,30 @@ public sealed class Viewport
             return;
 
         float target = _zoomTarget.Value;
-        float current = _zoom;
+        float dt = Math.Max(0f, dtSeconds);
 
-        float t = 1f - (float)Math.Exp(-_zoomLerpPerSecond * Math.Max(0f, dtSeconds));
+        if (_zoomDurationSeconds is { } durationSeconds)
+        {
+            _zoomElapsedSeconds += dt;
+
+            // Duration-based APIs should complete at the requested time rather
+            // than allowing the exponential tail to continue indefinitely.
+            if (_zoomElapsedSeconds >= durationSeconds)
+            {
+                SnapZoom(target);
+                return;
+            }
+        }
+
+        float current = _zoom;
+        float t = 1f - (float)Math.Exp(-_zoomLerpPerSecond * dt);
         float newZoom = current + (target - current) * t;
 
         Zoom = newZoom; // go through property so events fire
 
         // Close enough → snap and finish.
         if (Math.Abs(newZoom - target) < 1e-4f)
-        {
-            Zoom = target;
-            _zoomTarget = null;
-            _zoomLerpPerSecond = 0f;
-        }
+            SnapZoom(target);
     }
 
     #endregion zoom zoom

--- a/Gondwana/Rendering/Views/Viewport.cs
+++ b/Gondwana/Rendering/Views/Viewport.cs
@@ -15,6 +15,7 @@ public sealed class Viewport
     private float _zoomLerpPerSecond;
     private float? _zoomDurationSeconds;
     private float _zoomElapsedSeconds;
+    private float _zoomStart;
 
     /// <summary>
     /// Fired whenever <see cref="TargetRectPx"/> changes (viewport resized or moved).
@@ -97,6 +98,8 @@ public sealed class Viewport
         _zoomLerpPerSecond = 0f;
         _zoomDurationSeconds = null;
         _zoomElapsedSeconds = 0f;
+        _zoomStart = zoom;
+
         Zoom = zoom;
     }
 
@@ -112,6 +115,7 @@ public sealed class Viewport
             return;
         }
 
+        _zoomStart = _zoom;
         _zoomTarget = targetZoom;
         _zoomLerpPerSecond = lerpPerSecond;
         _zoomDurationSeconds = null;
@@ -130,13 +134,14 @@ public sealed class Viewport
             return;
         }
 
-        // Same math as Camera.PanToOverDuration: exp(-k*T) = 0.01 → k = -ln(0.01) / T
-        float k = -(float)Math.Log(0.01f) / durationSeconds;
-
+        _zoomStart = _zoom;
         _zoomTarget = targetZoom;
-        _zoomLerpPerSecond = k;
+
         _zoomDurationSeconds = durationSeconds;
         _zoomElapsedSeconds = 0f;
+
+        // The fixed-duration path calculates progress directly.
+        _zoomLerpPerSecond = 0f;
     }
 
     /// <summary>
@@ -145,7 +150,7 @@ public sealed class Viewport
     /// </summary>
     internal void UpdateZoom(float dtSeconds)
     {
-        if (_zoomTarget is null || _zoomLerpPerSecond <= 0f)
+        if (_zoomTarget is null)
             return;
 
         float target = _zoomTarget.Value;
@@ -153,27 +158,39 @@ public sealed class Viewport
 
         if (_zoomDurationSeconds is { } durationSeconds)
         {
-            _zoomElapsedSeconds += dt;
+            _zoomElapsedSeconds = Math.Min(_zoomElapsedSeconds + dt, durationSeconds);
 
-            // Duration-based APIs should complete at the requested time rather
-            // than allowing the exponential tail to continue indefinitely.
+            float progress = durationSeconds > 0f ? _zoomElapsedSeconds / durationSeconds : 1f;
+
+            // Preserve the existing exponential ease-out character, but normalize
+            // it so progress reaches exactly 1 at the requested duration.
+            const float decay = 4.605170186f; // -ln(0.01)
+
+            float normalization = 1f - MathF.Exp(-decay);
+            float easedProgress = (1f - MathF.Exp(-decay * progress)) / normalization;
+
+            Zoom = _zoomStart + (target - _zoomStart) * easedProgress;
+
             if (_zoomElapsedSeconds >= durationSeconds)
             {
+                // This no longer causes a visible jump: easedProgress is already 1.
                 SnapZoom(target);
-                return;
             }
+
+            return;
         }
 
-        float current = _zoom;
-        float t = 1f - (float)Math.Exp(-_zoomLerpPerSecond * dt);
-        float newZoom = current + (target - current) * t;
+        if (_zoomLerpPerSecond <= 0f)
+            return;
 
-        Zoom = newZoom; // go through property so events fire
+        float t = 1f - MathF.Exp(-_zoomLerpPerSecond * dt);
 
-        // Close enough → snap and finish.
+        float newZoom = _zoom + (target - _zoom) * t;
+
+        Zoom = newZoom;
+
         if (Math.Abs(newZoom - target) < 1e-4f)
             SnapZoom(target);
     }
-
     #endregion zoom zoom
 }

--- a/Testing/Gondwana.Tests/Drawing/Direct/TextBlockZoomTests.cs
+++ b/Testing/Gondwana.Tests/Drawing/Direct/TextBlockZoomTests.cs
@@ -1,0 +1,54 @@
+using Gondwana.Drawing.Direct;
+
+namespace Gondwana.Tests.Drawing.Direct;
+
+/// <summary>
+/// Verifies that TextBlock follows Gondwana's conventional zoom contract:
+/// values above one zoom world-space content in, while view-space text
+/// remains expressed directly in screen pixels.
+/// </summary>
+public sealed class TextBlockZoomTests
+{
+    [Theory]
+    [InlineData(0.5f)]
+    [InlineData(1f)]
+    [InlineData(2f)]
+    [InlineData(4f)]
+    public void ResolveTextScale_SceneLayerMode_UsesViewportZoom(
+        float viewportZoom)
+    {
+        float scale = TextBlock.ResolveTextScale(
+            DirectDrawingMode.SceneLayer,
+            viewportZoom);
+
+        Assert.Equal(viewportZoom, scale);
+    }
+
+    [Theory]
+    [InlineData(0.5f)]
+    [InlineData(1f)]
+    [InlineData(2f)]
+    [InlineData(4f)]
+    public void ResolveTextScale_ViewMode_RemainsScreenSized(
+        float viewportZoom)
+    {
+        float scale = TextBlock.ResolveTextScale(
+            DirectDrawingMode.View,
+            viewportZoom);
+
+        Assert.Equal(1f, scale);
+    }
+
+    [Theory]
+    [InlineData(0f)]
+    [InlineData(-1f)]
+    public void ResolveTextScale_InvalidSceneLayerZoom_FallsBackToOne(
+        float viewportZoom)
+    {
+        float scale = TextBlock.ResolveTextScale(
+            DirectDrawingMode.SceneLayer,
+            viewportZoom);
+
+        Assert.Equal(1f, scale);
+    }
+}

--- a/Testing/Gondwana.Tests/ViewAnchoredZoomTests.cs
+++ b/Testing/Gondwana.Tests/ViewAnchoredZoomTests.cs
@@ -1,0 +1,107 @@
+using System.Drawing;
+using Gondwana.Rendering.Views;
+using Gondwana.Scenes;
+
+namespace Gondwana.Tests.Rendering.Views;
+
+public sealed class ViewAnchoredZoomTests
+{
+    [Fact]
+    public void ZoomAroundScreenPoint_WhenAnimated_PreservesWorldAnchorEveryUpdate()
+    {
+        using var scene = new Scene();
+        var layer = scene.AddLayer(
+            100,
+            100,
+            parallax: 0.65f);
+
+        var viewport = new Viewport
+        {
+            TargetRectPx = new Rectangle(100, 50, 800, 600),
+            ScreenOffsetPx = new PointF(20f, 10f),
+            Zoom = 1f
+        };
+
+        var camera = new Camera(scene);
+        var view = new View(camera, viewport);
+        camera.SnapTo(new PointF(200f, 100f));
+
+        var screenAnchor = new PointF(500f, 350f);
+        PointF worldAnchor = view.ScreenPxToWorldPx(layer, screenAnchor);
+
+        view.ZoomAroundScreenPoint(
+            layer,
+            screenAnchor,
+            targetZoom: 2f,
+            durationSeconds: 0.75f);
+
+        for (int i = 0; i < 5; i++)
+        {
+            view.Update(0.15f);
+
+            PointF currentWorldAnchor =
+                view.ScreenPxToWorldPx(layer, screenAnchor);
+
+            AssertClose(worldAnchor, currentWorldAnchor);
+        }
+
+        Assert.Equal(2f, viewport.Zoom);
+        Assert.False(viewport.IsZoomAnimating);
+    }
+
+    [Fact]
+    public void ZoomAroundScreenPoint_WhenRetargeted_PreservesAnchorWithoutWobble()
+    {
+        using var scene = new Scene();
+        var layer = scene.AddLayer(100, 100);
+
+        var viewport = new Viewport
+        {
+            TargetRectPx = new Rectangle(0, 0, 800, 600),
+            Zoom = 1f
+        };
+
+        var camera = new Camera(scene);
+        var view = new View(camera, viewport);
+        camera.SnapTo(new PointF(80f, 40f));
+
+        var screenAnchor = new PointF(375f, 225f);
+        PointF worldAnchor = view.ScreenPxToWorldPx(layer, screenAnchor);
+
+        view.ZoomAroundScreenPoint(
+            layer,
+            screenAnchor,
+            targetZoom: 1.5f,
+            durationSeconds: 0.75f);
+
+        view.Update(0.20f);
+        AssertClose(
+            worldAnchor,
+            view.ScreenPxToWorldPx(layer, screenAnchor));
+
+        view.ZoomAroundScreenPoint(
+            layer,
+            screenAnchor,
+            targetZoom: 2f,
+            durationSeconds: 0.75f);
+
+        for (int i = 0; i < 5; i++)
+        {
+            view.Update(0.15f);
+            AssertClose(
+                worldAnchor,
+                view.ScreenPxToWorldPx(layer, screenAnchor));
+        }
+
+        Assert.Equal(2f, viewport.Zoom);
+    }
+
+    private static void AssertClose(
+        PointF expected,
+        PointF actual,
+        float tolerance = 0.001f)
+    {
+        Assert.InRange(actual.X, expected.X - tolerance, expected.X + tolerance);
+        Assert.InRange(actual.Y, expected.Y - tolerance, expected.Y + tolerance);
+    }
+}

--- a/Testing/Gondwana.Tests/ViewCoordinateConversionTests.cs
+++ b/Testing/Gondwana.Tests/ViewCoordinateConversionTests.cs
@@ -1,0 +1,262 @@
+﻿using System.Drawing;
+using Gondwana.Rendering.Views;
+using Gondwana.Scenes;
+
+namespace Gondwana.Tests.Rendering.Views;
+
+/// <summary>
+/// Verifies the public zoom contract and the invertibility of View coordinate conversions.
+/// </summary>
+public sealed class ViewCoordinateConversionTests
+{
+    [Theory]
+    [InlineData(1f, 100f)]
+    [InlineData(2f, 200f)]
+    [InlineData(0.5f, 50f)]
+    public void WorldPxToScreenPx_AppliesConventionalZoom(
+        float zoom,
+        float expectedScreenDisplacement)
+    {
+        using var scene = new Scene();
+        var layer = scene.AddLayer(100, 100);
+        var view = CreateView(
+            scene,
+            zoom: zoom,
+            cameraPositionPx: new PointF(100f, 50f));
+
+        PointF screenPx = view.WorldPxToScreenPx(
+            layer,
+            new PointF(200f, 50f));
+
+        AssertClose(expectedScreenDisplacement, screenPx.X);
+        AssertClose(0f, screenPx.Y);
+    }
+
+    [Theory]
+    [InlineData(1f, 100f)]
+    [InlineData(2f, 50f)]
+    [InlineData(0.5f, 200f)]
+    public void ScreenPxToWorldPx_AppliesInverseZoom(
+        float zoom,
+        float expectedWorldDisplacement)
+    {
+        using var scene = new Scene();
+        var layer = scene.AddLayer(100, 100);
+        var view = CreateView(
+            scene,
+            zoom: zoom,
+            cameraPositionPx: new PointF(100f, 50f));
+
+        PointF worldPx = view.ScreenPxToWorldPx(
+            layer,
+            new PointF(100f, 0f));
+
+        AssertClose(100f + expectedWorldDisplacement, worldPx.X);
+        AssertClose(50f, worldPx.Y);
+    }
+
+    [Fact]
+    public void WorldPxToScreenPx_ReturnsAbsoluteAdapterCoordinates()
+    {
+        using var scene = new Scene();
+        var layer = scene.AddLayer(100, 100);
+        var view = CreateView(
+            scene,
+            zoom: 2f,
+            targetRectPx: new Rectangle(400, 100, 800, 600),
+            screenOffsetPx: new PointF(10f, 20f),
+            cameraPositionPx: new PointF(100f, 50f));
+
+        PointF screenPx = view.WorldPxToScreenPx(
+            layer,
+            new PointF(125f, 70f));
+
+        AssertClose(460f, screenPx.X);
+        AssertClose(160f, screenPx.Y);
+    }
+
+    [Fact]
+    public void PointConversions_RoundTripWithCameraOffsetsZoomAndParallax()
+    {
+        using var scene = new Scene();
+        var layer = scene.AddLayer(
+            100,
+            100,
+            parallax: 0.65f);
+
+        var view = CreateView(
+            scene,
+            zoom: 1.75f,
+            targetRectPx: new Rectangle(300, 120, 900, 500),
+            screenOffsetPx: new PointF(7f, -3f),
+            cameraPositionPx: new PointF(120f, 80f));
+
+        var originalWorldPx = new PointF(450.25f, 275.75f);
+
+        PointF screenPx = view.WorldPxToScreenPx(
+            layer,
+            originalWorldPx);
+
+        PointF restoredWorldPx = view.ScreenPxToWorldPx(
+            layer,
+            screenPx);
+
+        AssertClose(originalWorldPx, restoredWorldPx);
+    }
+
+    [Fact]
+    public void WorldRectToScreenRect_ScalesPositionAndSizeByZoom()
+    {
+        using var scene = new Scene();
+        var layer = scene.AddLayer(100, 100);
+        var view = CreateView(
+            scene,
+            zoom: 2f,
+            cameraPositionPx: new PointF(100f, 50f));
+
+        RectangleF screenRect = view.WorldRectToScreenRect(
+            layer,
+            new RectangleF(125f, 70f, 40f, 30f));
+
+        AssertClose(
+            new RectangleF(50f, 40f, 80f, 60f),
+            screenRect);
+    }
+
+    [Fact]
+    public void RectangleConversions_RoundTripWithCameraOffsetsZoomAndParallax()
+    {
+        using var scene = new Scene();
+        var layer = scene.AddLayer(
+            100,
+            100,
+            parallax: 0.65f);
+
+        var view = CreateView(
+            scene,
+            zoom: 1.75f,
+            targetRectPx: new Rectangle(300, 120, 900, 500),
+            screenOffsetPx: new PointF(7f, -3f),
+            cameraPositionPx: new PointF(120f, 80f));
+
+        var originalWorldRect =
+            new RectangleF(450.25f, 275.75f, 125.5f, 64.25f);
+
+        RectangleF screenRect = view.WorldRectToScreenRect(
+            layer,
+            originalWorldRect);
+
+        RectangleF restoredWorldRect = view.ScreenRectToWorldRect(
+            layer,
+            screenRect);
+
+        AssertClose(originalWorldRect, restoredWorldRect);
+    }
+
+    [Fact]
+    public void ZoomAroundScreenPoint_WhenSnapped_PreservesWorldPointUnderCursor()
+    {
+        using var scene = new Scene();
+        var layer = scene.AddLayer(
+            100,
+            100,
+            parallax: 0.5f);
+
+        var view = CreateView(
+            scene,
+            zoom: 1f,
+            targetRectPx: new Rectangle(100, 50, 800, 600),
+            screenOffsetPx: new PointF(20f, 10f),
+            cameraPositionPx: new PointF(200f, 100f));
+
+        var cursorScreenPx = new PointF(500f, 350f);
+        PointF worldBefore = view.ScreenPxToWorldPx(
+            layer,
+            cursorScreenPx);
+
+        view.ZoomAroundScreenPoint(
+            layer,
+            cursorScreenPx,
+            targetZoom: 2f,
+            durationSeconds: 0f);
+
+        PointF worldAfter = view.ScreenPxToWorldPx(
+            layer,
+            cursorScreenPx);
+
+        Assert.Equal(2f, view.Viewport.Zoom);
+        AssertClose(worldBefore, worldAfter);
+    }
+
+    [Theory]
+    [InlineData(1f, 800f, 600f)]
+    [InlineData(2f, 400f, 300f)]
+    [InlineData(0.5f, 1600f, 1200f)]
+    public void VisibleWorldSizePx_UsesReciprocalZoom(
+        float zoom,
+        float expectedWidth,
+        float expectedHeight)
+    {
+        var viewport = new Viewport
+        {
+            TargetRectPx = new Rectangle(0, 0, 800, 600),
+            Zoom = zoom
+        };
+
+        AssertClose(expectedWidth, viewport.VisibleWorldSizePx.Width);
+        AssertClose(expectedHeight, viewport.VisibleWorldSizePx.Height);
+    }
+
+    private static View CreateView(
+        Scene scene,
+        float zoom,
+        Rectangle? targetRectPx = null,
+        PointF? screenOffsetPx = null,
+        PointF? cameraPositionPx = null)
+    {
+        var viewport = new Viewport
+        {
+            TargetRectPx = targetRectPx ?? new Rectangle(0, 0, 800, 600),
+            ScreenOffsetPx = screenOffsetPx ?? PointF.Empty,
+            Zoom = zoom
+        };
+
+        var camera = new Camera(scene);
+        var view = new View(camera, viewport);
+
+        camera.SnapTo(cameraPositionPx ?? PointF.Empty);
+
+        return view;
+    }
+
+    private static void AssertClose(
+        float expected,
+        float actual,
+        float tolerance = 0.001f)
+    {
+        Assert.InRange(
+            actual,
+            expected - tolerance,
+            expected + tolerance);
+    }
+
+    private static void AssertClose(
+        PointF expected,
+        PointF actual,
+        float tolerance = 0.001f)
+    {
+        AssertClose(expected.X, actual.X, tolerance);
+        AssertClose(expected.Y, actual.Y, tolerance);
+    }
+
+    private static void AssertClose(
+        RectangleF expected,
+        RectangleF actual,
+        float tolerance = 0.001f)
+    {
+        AssertClose(expected.X, actual.X, tolerance);
+        AssertClose(expected.Y, actual.Y, tolerance);
+        AssertClose(expected.Width, actual.Width, tolerance);
+        AssertClose(expected.Height, actual.Height, tolerance);
+    }
+}

--- a/Testing/Gondwana.Tests/ViewportZoomDurationTests.cs
+++ b/Testing/Gondwana.Tests/ViewportZoomDurationTests.cs
@@ -1,0 +1,41 @@
+using Gondwana.Rendering.Views;
+
+namespace Gondwana.Tests.Rendering.Views;
+
+public sealed class ViewportZoomDurationTests
+{
+    [Fact]
+    public void ZoomToOverDuration_SnapsToTargetWhenDurationElapses()
+    {
+        var viewport = new Viewport { Zoom = 1f };
+
+        viewport.ZoomToOverDuration(
+            targetZoom: 2f,
+            durationSeconds: 0.75f);
+
+        viewport.UpdateZoom(0.50f);
+
+        Assert.True(viewport.IsZoomAnimating);
+        Assert.NotEqual(2f, viewport.Zoom);
+
+        viewport.UpdateZoom(0.25f);
+
+        Assert.Equal(2f, viewport.Zoom);
+        Assert.False(viewport.IsZoomAnimating);
+    }
+
+    [Fact]
+    public void ZoomToOverDuration_WhenFrameExceedsRemainingTime_SnapsToTarget()
+    {
+        var viewport = new Viewport { Zoom = 1f };
+
+        viewport.ZoomToOverDuration(
+            targetZoom: 0.5f,
+            durationSeconds: 0.20f);
+
+        viewport.UpdateZoom(0.25f);
+
+        Assert.Equal(0.5f, viewport.Zoom);
+        Assert.False(viewport.IsZoomAnimating);
+    }
+}


### PR DESCRIPTION
- Fixes zoom behavior so values > 1 mean zoomed-in (larger) and < 1 mean zoomed-out (smaller), eliminating zoom jumps a
- Refactors view/viewport zoom calculations with updated coordinate conversion logic and anchored-zoom support
- Removes arbitrary time division from movement calculations for more consistent motion
- Adds comprehensive test coverage for zoom, anchored zoom, viewport zoom duration, and coordinate conversions