### PR TITLE
feat(rendering): add oblique left coordinate system

### DIFF
--- a/Demos/Gondwana.CoordinateTest/Game.cs
+++ b/Demos/Gondwana.CoordinateTest/Game.cs
@@ -244,8 +244,8 @@ public class Game : IDisposable
     private Scene? CreateInitialScene()
     {
         var scene = new Scene();
-        var sceneLayer1 = scene.AddLayer(60, 5, 64, 64, 10, 1f, CoordinateSystemTypes.HexAxialPointedTop);
-        var sceneLayer2 = scene.AddLayer(60, 5, 32, 32, 5, 0.5f, CoordinateSystemTypes.HexAxialPointedTop);
+        var sceneLayer1 = scene.AddLayer(60, 5, 64, 64, 10, 1f, CoordinateSystemTypes.IsometricAxial);
+        var sceneLayer2 = scene.AddLayer(60, 5, 32, 32, 5, 0.5f, CoordinateSystemTypes.IsometricAxial);
 
         sceneLayer1.ShowGridLines = true;
         sceneLayer1.ShowCollisionBoxes = true;

--- a/Gondwana/Drawing/Coordinates/CoordinateSystemTypes.cs
+++ b/Gondwana/Drawing/Coordinates/CoordinateSystemTypes.cs
@@ -36,6 +36,12 @@ public enum CoordinateSystemTypes
 
     /// <summary>
     /// Oblique projection using a right-receding, sheared square lattice.
+    /// Numeric value 5 is retained for compatibility with existing serialized layers.
     /// </summary>
-    Oblique = 5
+    ObliqueRight = 5,
+
+    /// <summary>
+    /// Oblique projection using a left-receding, sheared square lattice.
+    /// </summary>
+    ObliqueLeft = 6
 }

--- a/Gondwana/Drawing/Coordinates/ISceneLayerCoordinates.cs
+++ b/Gondwana/Drawing/Coordinates/ISceneLayerCoordinates.cs
@@ -12,15 +12,15 @@ namespace Gondwana.Drawing.Coordinates;
 internal interface ISceneLayerCoordinates
 {
     /// <summary>
-    /// Returns the world-space pixel position of the *top-left anchor* of the tile
-    /// at the given grid coordinate (col,row) in this SceneLayer.
+    /// Returns the projection-defined world-space pixel anchor of the tile at the
+    /// given grid coordinate (col,row) in this SceneLayer.
     /// 
     /// This is the starting pixel used to draw the tile’s image or polygon.
     /// Every tile's shape (square, isometric, hex) is positioned by taking this
     /// anchor pixel and adding its local geometry.
     /// 
-    /// In other words: given grid coordinates, this tells you exactly where on
-    /// the world the tile begins.
+    /// For rectangular and oblique tiles this is the top-left corner of the image
+    /// bounding box. For isometric diamonds it is the top vertex.
     /// </summary>
     Point GetAnchorPixelAtSceneLayerCoordinates(SceneLayer sceneLayer, PointF layerPoint);
 

--- a/Gondwana/Drawing/Coordinates/IsometricAxialCoordinates.cs
+++ b/Gondwana/Drawing/Coordinates/IsometricAxialCoordinates.cs
@@ -4,12 +4,10 @@ using Gondwana.Scenes;
 namespace Gondwana.Drawing.Coordinates;
 
 /// <summary>
-/// Diagonal-Isometric (Square Matrix, **no 45° rotation**)
-/// - World/layout is axis-aligned (rectangular bounds, no dx/dy mixing)
-/// - Each grid cell renders a diamond inside its W×H footprint
-/// - Column centers advance by (W/2, 0); row centers by (0, H/2)
-///   (i.e., tight diamond packing without rotating the world axes)
-/// Pixel anchor = TOP vertex of the diamond
+/// Axial isometric projection using a horizontal column axis and a diagonal row axis.
+/// Each grid cell renders a diamond inside its W×H footprint. Column anchors advance
+/// by (W, 0), while row anchors advance by (W/2, H/2), packing the diamonds edge-to-edge.
+/// The pixel anchor is the top vertex of the diamond.
 /// </summary>
 internal sealed class IsometricAxialCoordinates : ISceneLayerCoordinates
 {
@@ -35,13 +33,8 @@ internal sealed class IsometricAxialCoordinates : ISceneLayerCoordinates
         int originX = sceneLayer.OriginPx.X;
         int originY = sceneLayer.OriginPx.Y;
 
-        // gp is already in grid-space.
-        float gx = gp.X;
-        float gy = gp.Y;
-
-        // STEP BY FULL TILE SIZE (W, H)
-        float px = -originX + gx * W;
-        float py = -originY + gy * H;
+        float px = -originX + gp.X * W + gp.Y * halfW;
+        float py = -originY + gp.Y * halfH;
 
         return new Point((int)Math.Floor(px), (int)Math.Floor(py));
     }
@@ -59,9 +52,8 @@ internal sealed class IsometricAxialCoordinates : ISceneLayerCoordinates
         int originX = sceneLayer.OriginPx.X;
         int originY = sceneLayer.OriginPx.Y;
 
-        // Inverse for full-tile stepping
-        float gxF = (pixelPt.X + originX) / W;
-        float gyF = (pixelPt.Y + originY) / H;
+        float gyF = (pixelPt.Y + originY) / halfH;
+        float gxF = (pixelPt.X + originX - gyF * halfW) / W;
 
         return new PointF(gxF, gyF);
     }

--- a/Gondwana/Drawing/Coordinates/ObliqueLeftCoordinates.cs
+++ b/Gondwana/Drawing/Coordinates/ObliqueLeftCoordinates.cs
@@ -1,0 +1,296 @@
+using System.Drawing;
+using Gondwana.Scenes;
+
+namespace Gondwana.Drawing.Coordinates;
+
+/// <summary>
+/// Oblique projection using a left-receding, sheared square lattice.
+/// Columns remain horizontal while rows advance down and to the left,
+/// producing a parallelogram tile footprint rather than an isometric diamond.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="SceneLayer.TileWidth"/> and <see cref="SceneLayer.TileHeight"/>
+/// describe the full pixel bounding box of each rendered tile.
+/// The horizontal skew is half the tile width; the remaining width forms the
+/// tile's horizontal top and bottom edges.
+/// </para>
+/// <para>
+/// Tile artwork should fit the resulting parallelogram footprint, typically
+/// using transparency in the unused corners of the tile's bounding box.
+/// </para>
+/// </remarks>
+internal sealed class ObliqueLeftCoordinates : ISceneLayerCoordinates
+{
+    /// <summary>
+    /// Gets the anchor pixel position for a tile at the specified scene layer coordinates.
+    /// The anchor is the top-left corner of the tile's full pixel bounding box.
+    /// </summary>
+    /// <param name="sceneLayer">The scene layer containing the tile.</param>
+    /// <param name="layerPoint">The scene layer coordinates (column, row).</param>
+    /// <returns>The pixel position of the tile's bounding-box anchor.</returns>
+    public Point GetAnchorPixelAtSceneLayerCoordinates(SceneLayer sceneLayer, PointF layerPoint)
+    {
+        GetGeometry(sceneLayer, out _, out int H, out int skewX, out int faceWidth);
+
+        float x = -sceneLayer.OriginPx.X
+                  + layerPoint.X * faceWidth
+                  - layerPoint.Y * skewX;
+
+        float y = -sceneLayer.OriginPx.Y
+                  + layerPoint.Y * H;
+
+        return new Point(
+            (int)Math.Floor(x),
+            (int)Math.Floor(y));
+    }
+
+    /// <summary>
+    /// Converts a pixel-space point into continuous oblique grid coordinates.
+    /// </summary>
+    /// <param name="sceneLayer">The scene layer to query.</param>
+    /// <param name="pixelPt">The world-space pixel position to convert.</param>
+    /// <returns>The corresponding continuous scene layer coordinates.</returns>
+    public PointF GetSceneLayerCoordinatesAtPixel(SceneLayer sceneLayer, PointF pixelPt)
+    {
+        GetGeometry(sceneLayer, out _, out int H, out int skewX, out int faceWidth);
+
+        float row = (pixelPt.Y + sceneLayer.OriginPx.Y) / H;
+        float col = (pixelPt.X + sceneLayer.OriginPx.X + row * skewX) / faceWidth;
+
+        return new PointF(col, row);
+    }
+
+    /// <summary>
+    /// Gets all scene layer tiles whose pixel bounds intersect the specified range.
+    /// </summary>
+    /// <param name="sceneLayer">The scene layer to query.</param>
+    /// <param name="worldPixelRange">The world-space pixel range to search.</param>
+    /// <param name="includeOverhang">Whether tile overhang is included in intersection tests.</param>
+    /// <returns>The tiles intersecting the specified pixel range.</returns>
+    public List<SceneLayerTile> GetSceneLayerTilesInPixelRange(
+        SceneLayer sceneLayer,
+        Rectangle worldPixelRange,
+        bool includeOverhang)
+    {
+        var result = new List<SceneLayerTile>();
+
+        var upperLeft = GetSceneLayerCoordinatesAtPixel(
+            sceneLayer,
+            new PointF(worldPixelRange.Left, worldPixelRange.Top));
+
+        var upperRight = GetSceneLayerCoordinatesAtPixel(
+            sceneLayer,
+            new PointF(worldPixelRange.Right, worldPixelRange.Top));
+
+        var lowerLeft = GetSceneLayerCoordinatesAtPixel(
+            sceneLayer,
+            new PointF(worldPixelRange.Left, worldPixelRange.Bottom));
+
+        var lowerRight = GetSceneLayerCoordinatesAtPixel(
+            sceneLayer,
+            new PointF(worldPixelRange.Right, worldPixelRange.Bottom));
+
+        int minX = (int)Math.Floor(new[]
+        {
+            upperLeft.X,
+            upperRight.X,
+            lowerLeft.X,
+            lowerRight.X
+        }.Min()) - 1;
+
+        int maxX = (int)Math.Ceiling(new[]
+        {
+            upperLeft.X,
+            upperRight.X,
+            lowerLeft.X,
+            lowerRight.X
+        }.Max()) + 1;
+
+        int minY = (int)Math.Floor(new[]
+        {
+            upperLeft.Y,
+            upperRight.Y,
+            lowerLeft.Y,
+            lowerRight.Y
+        }.Min()) - 1;
+
+        int maxY = (int)Math.Ceiling(new[]
+        {
+            upperLeft.Y,
+            upperRight.Y,
+            lowerLeft.Y,
+            lowerRight.Y
+        }.Max()) + 1;
+
+        for (int y = minY; y <= maxY; y++)
+        {
+            for (int x = minX; x <= maxX; x++)
+            {
+                var tile = sceneLayer[x, y];
+                if (tile is null)
+                    continue;
+
+                var tileRange = GetPixelRangeForTile(tile, includeOverhang);
+                if (tileRange.IntersectsWith(worldPixelRange))
+                    result.Add(tile);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Gets the pixel bounding rectangle for the specified tile.
+    /// </summary>
+    /// <param name="tile">The tile whose bounds are requested.</param>
+    /// <param name="includeOverhang">Whether tile overhang is included in the bounds.</param>
+    /// <returns>The tile's pixel bounding rectangle.</returns>
+    public Rectangle GetPixelRangeForTile(Tile tile, bool includeOverhang)
+    {
+        var anchor = GetAnchorPixelAtSceneLayerCoordinates(
+            tile.SceneLayer,
+            tile.SceneLayerCoordinates);
+
+        var baseRect = new Rectangle(
+            anchor.X,
+            anchor.Y,
+            tile.SceneLayer.TileWidth,
+            tile.SceneLayer.TileHeight);
+
+        return TileBounds.ApplyOverhang(baseRect, tile.Overhang, includeOverhang);
+    }
+
+    /// <summary>
+    /// Gets the combined pixel bounding rectangle for the specified tiles.
+    /// </summary>
+    /// <param name="tileList">The tiles whose combined bounds are requested.</param>
+    /// <param name="includeOverhang">Whether tile overhang is included in the bounds.</param>
+    /// <returns>The union of all tile bounds, or an empty rectangle when the list is empty.</returns>
+    public Rectangle GetPixelRangeForTileList(List<Tile> tileList, bool includeOverhang)
+    {
+        Rectangle result = Rectangle.Empty;
+
+        foreach (var tile in tileList)
+        {
+            var tileRange = GetPixelRangeForTile(tile, includeOverhang);
+            result = result.IsEmpty
+                ? tileRange
+                : Rectangle.Union(result, tileRange);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Gets the adjacent scene layer tile in the specified cardinal direction.
+    /// Oblique projection changes presentation only; topology remains a square grid.
+    /// </summary>
+    /// <param name="layerPoint">The source tile.</param>
+    /// <param name="direction">The direction of the adjacent tile.</param>
+    /// <returns>The adjacent tile, or <see langword="null"/> when none exists.</returns>
+    public SceneLayerTile GetAdjacentSceneLayerTile(
+        SceneLayerTile layerPoint,
+        CardinalDirections direction)
+    {
+        var sceneLayer = layerPoint.SceneLayer;
+        int x = layerPoint.GridCoordinatesAbs.X;
+        int y = layerPoint.GridCoordinatesAbs.Y;
+
+        return direction switch
+        {
+            CardinalDirections.N => sceneLayer[x, y - 1],
+            CardinalDirections.NE => sceneLayer[x + 1, y - 1],
+            CardinalDirections.E => sceneLayer[x + 1, y],
+            CardinalDirections.SE => sceneLayer[x + 1, y + 1],
+            CardinalDirections.S => sceneLayer[x, y + 1],
+            CardinalDirections.SW => sceneLayer[x - 1, y + 1],
+            CardinalDirections.W => sceneLayer[x - 1, y],
+            CardinalDirections.NW => sceneLayer[x - 1, y - 1],
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// Gets the four pixel-space vertices of the tile's oblique parallelogram.
+    /// </summary>
+    /// <param name="tile">The tile whose polygon is requested.</param>
+    /// <param name="includeOverhang">Whether tile overhang is reflected in the polygon.</param>
+    /// <returns>The parallelogram vertices in clockwise order.</returns>
+    public Point[] GetPolygonPts(Tile tile, bool includeOverhang)
+    {
+        GetGeometry(
+            tile.SceneLayer,
+            out int W,
+            out int H,
+            out int skewX,
+            out int faceWidth);
+
+        var anchor = GetAnchorPixelAtSceneLayerCoordinates(
+            tile.SceneLayer,
+            tile.SceneLayerCoordinates);
+
+        var overhang = includeOverhang
+            ? tile.Overhang
+            : Spacing.None;
+
+        return new[]
+        {
+            new Point(
+                anchor.X + skewX - overhang.Left,
+                anchor.Y - overhang.Top),
+
+            new Point(
+                anchor.X + W + overhang.Right,
+                anchor.Y - overhang.Top),
+
+            new Point(
+                anchor.X + faceWidth + overhang.Right,
+                anchor.Y + H + overhang.Bottom),
+
+            new Point(
+                anchor.X - overhang.Left,
+                anchor.Y + H + overhang.Bottom)
+        };
+    }
+
+    /// <summary>
+    /// Finds equivalent scene layer coordinates within the specified bounds by wrapping values.
+    /// </summary>
+    /// <param name="valColRow">The input coordinates.</param>
+    /// <param name="xUpperBound">The inclusive upper bound for the X coordinate.</param>
+    /// <param name="yUpperBound">The inclusive upper bound for the Y coordinate.</param>
+    /// <returns>The wrapped coordinates within the supplied bounds.</returns>
+    public PointF FindEquivalentSceneLayerCoordinates(
+        PointF valColRow,
+        int xUpperBound,
+        int yUpperBound)
+    {
+        float modX = valColRow.X % (xUpperBound + 1);
+        float modY = valColRow.Y % (yUpperBound + 1);
+
+        if (modX < 0)
+            modX += xUpperBound + 1;
+
+        if (modY < 0)
+            modY += yUpperBound + 1;
+
+        return new PointF(modX, modY);
+    }
+
+    private static void GetGeometry(
+        SceneLayer sceneLayer,
+        out int width,
+        out int height,
+        out int skewX,
+        out int faceWidth)
+    {
+        width = sceneLayer.TileWidth;
+        height = sceneLayer.TileHeight;
+
+        // The full tile image remains W x H. Half of W is used by the
+        // row-wise shear; the remaining width is the horizontal tile face.
+        skewX = width / 2;
+        faceWidth = width - skewX;
+    }
+}

--- a/Gondwana/Drawing/Coordinates/ObliqueRightCoordinates.cs
+++ b/Gondwana/Drawing/Coordinates/ObliqueRightCoordinates.cs
@@ -20,7 +20,7 @@ namespace Gondwana.Drawing.Coordinates;
 /// using transparency in the unused corners of the tile's bounding box.
 /// </para>
 /// </remarks>
-internal sealed class ObliqueCoordinates : ISceneLayerCoordinates
+internal sealed class ObliqueRightCoordinates : ISceneLayerCoordinates
 {
     /// <summary>
     /// Gets the anchor pixel position for a tile at the specified scene layer coordinates.

--- a/Gondwana/Scenes/SceneLayer.cs
+++ b/Gondwana/Scenes/SceneLayer.cs
@@ -219,7 +219,8 @@ public class SceneLayer : IEnumerable<SceneLayerTile>, IDisposable
     /// <item><description><see cref="CoordinateSystemTypes.IsometricAxial"/> - Axial isometric projection</description></item>
     /// <item><description><see cref="CoordinateSystemTypes.HexAxialFlatTop"/> - Hexagonal grid with flat-top orientation</description></item>
     /// <item><description><see cref="CoordinateSystemTypes.HexAxialPointedTop"/> - Hexagonal grid with pointed-top orientation</description></item>
-    /// <item><description><see cref="CoordinateSystemTypes.Oblique"/> - Oblique projection</description></item>
+    /// <item><description><see cref="CoordinateSystemTypes.ObliqueRight"/> - Right-receding oblique projection</description></item>
+    /// <item><description><see cref="CoordinateSystemTypes.ObliqueLeft"/> - Left-receding oblique projection</description></item>
     /// </list>
     /// <para>
     /// Changing the coordinate system after layer creation is supported but may produce unexpected
@@ -238,7 +239,8 @@ public class SceneLayer : IEnumerable<SceneLayerTile>, IDisposable
                 IsometricAxialCoordinates => CoordinateSystemTypes.IsometricAxial,
                 HexAxialFlatTopCoordinates => CoordinateSystemTypes.HexAxialFlatTop,
                 HexAxialPointedTop => CoordinateSystemTypes.HexAxialPointedTop,
-                ObliqueCoordinates => CoordinateSystemTypes.Oblique,
+                ObliqueRightCoordinates => CoordinateSystemTypes.ObliqueRight,
+                ObliqueLeftCoordinates => CoordinateSystemTypes.ObliqueLeft,
                 _ => throw new InvalidOperationException($"Unknown coordinate system type: {CoordinateSystem.GetType().Name}")
             };
         }
@@ -251,7 +253,8 @@ public class SceneLayer : IEnumerable<SceneLayerTile>, IDisposable
                 CoordinateSystemTypes.IsometricAxial => new IsometricAxialCoordinates(),
                 CoordinateSystemTypes.HexAxialFlatTop => new HexAxialFlatTopCoordinates(),
                 CoordinateSystemTypes.HexAxialPointedTop => new HexAxialPointedTop(),
-                CoordinateSystemTypes.Oblique => new ObliqueCoordinates(),
+                CoordinateSystemTypes.ObliqueRight => new ObliqueRightCoordinates(),
+                CoordinateSystemTypes.ObliqueLeft => new ObliqueLeftCoordinates(),
                 _ => throw new ArgumentOutOfRangeException(nameof(value), $"Unknown coordinate system type: {value}")
             };
         }
@@ -660,9 +663,9 @@ public class SceneLayer : IEnumerable<SceneLayerTile>, IDisposable
     }
 
     /// <summary>
-    /// Converts a grid coordinate (col,row) into the world-space pixel anchor
-    /// where that tile begins. This returns the tile's top-left anchor in world
-    /// pixels, not the tile center.
+    /// Converts a grid coordinate (col,row) into the projection-defined world-space
+    /// pixel anchor for that tile. Rectangular and oblique systems use the top-left
+    /// corner of the image bounds; isometric systems use the diamond's top vertex.
     /// </summary>
     public PointF GridToWorldPx(PointF grid) => CoordinateSystem.GetAnchorPixelAtSceneLayerCoordinates(this, grid);
 

--- a/Testing/Gondwana.Tests/Drawing/Coordinates/SceneLayerCoordinateSystemTests.cs
+++ b/Testing/Gondwana.Tests/Drawing/Coordinates/SceneLayerCoordinateSystemTests.cs
@@ -1,0 +1,157 @@
+using System.Drawing;
+using Gondwana.Drawing.Coordinates;
+using Gondwana.Scenes;
+
+namespace Gondwana.Tests.Drawing.Coordinates;
+
+public sealed class SceneLayerCoordinateSystemTests
+{
+    [Fact]
+    public void CoordinateSystemTypes_PreserveObliqueRightSerializedValue()
+    {
+        Assert.Equal(5, (int)CoordinateSystemTypes.ObliqueRight);
+        Assert.Equal(6, (int)CoordinateSystemTypes.ObliqueLeft);
+    }
+
+    [Fact]
+    public void IsometricAxial_UsesTightlyPackedAffineBasis()
+    {
+        using var scene = new Scene();
+        var layer = scene.AddLayer(
+            columnCount: 4,
+            rowCount: 4,
+            width: 64,
+            height: 32,
+            coordinateSystem: CoordinateSystemTypes.IsometricAxial);
+
+        Assert.Equal(new PointF(0f, 0f), layer.GridToWorldPx(new PointF(0f, 0f)));
+        Assert.Equal(new PointF(64f, 0f), layer.GridToWorldPx(new PointF(1f, 0f)));
+        Assert.Equal(new PointF(32f, 16f), layer.GridToWorldPx(new PointF(0f, 1f)));
+        Assert.Equal(new PointF(96f, 16f), layer.GridToWorldPx(new PointF(1f, 1f)));
+        Assert.Equal(new PointF(64f, 32f), layer.GridToWorldPx(new PointF(0f, 2f)));
+    }
+
+    [Fact]
+    public void IsometricAxial_WorldToGrid_InvertsAffineBasis()
+    {
+        using var scene = new Scene();
+        var layer = scene.AddLayer(
+            columnCount: 8,
+            rowCount: 8,
+            width: 64,
+            height: 32,
+            coordinateSystem: CoordinateSystemTypes.IsometricAxial);
+
+        Assert.Equal(new PointF(3f, 2f), layer.WorldPxToGrid(new PointF(256f, 32f)));
+        Assert.Equal(new PointF(1f, 1.5f), layer.WorldPxToGrid(new PointF(112f, 24f)));
+    }
+
+    [Fact]
+    public void IsometricAxial_AdjacentRowsShareDiamondEdge()
+    {
+        using var scene = new Scene();
+        var layer = scene.AddLayer(
+            columnCount: 2,
+            rowCount: 2,
+            width: 64,
+            height: 32,
+            coordinateSystem: CoordinateSystemTypes.IsometricAxial);
+
+        Point[] first = layer[0, 0].OutlinePointsWorld;
+        Point[] nextRow = layer[0, 1].OutlinePointsWorld;
+
+        Assert.Equal(first[1], nextRow[0]);
+        Assert.Equal(first[2], nextRow[3]);
+    }
+
+    [Theory]
+    [InlineData(CoordinateSystemTypes.ObliqueRight, 40f)]
+    [InlineData(CoordinateSystemTypes.ObliqueLeft, -40f)]
+    public void ObliqueRowsRecedeInSelectedDirection(
+        CoordinateSystemTypes coordinateSystem,
+        float expectedRowX)
+    {
+        using var scene = new Scene();
+        var layer = scene.AddLayer(
+            columnCount: 4,
+            rowCount: 4,
+            width: 80,
+            height: 48,
+            coordinateSystem: coordinateSystem);
+
+        Assert.Equal(new PointF(40f, 0f), layer.GridToWorldPx(new PointF(1f, 0f)));
+        Assert.Equal(new PointF(expectedRowX, 48f), layer.GridToWorldPx(new PointF(0f, 1f)));
+    }
+
+    [Theory]
+    [InlineData(CoordinateSystemTypes.ObliqueRight, 200f)]
+    [InlineData(CoordinateSystemTypes.ObliqueLeft, 40f)]
+    public void ObliqueWorldToGrid_InvertsSelectedShear(
+        CoordinateSystemTypes coordinateSystem,
+        float anchorX)
+    {
+        using var scene = new Scene();
+        var layer = scene.AddLayer(
+            columnCount: 5,
+            rowCount: 5,
+            width: 80,
+            height: 48,
+            coordinateSystem: coordinateSystem);
+
+        var world = new PointF(anchorX, 96f);
+        Assert.Equal(world, layer.GridToWorldPx(new PointF(3f, 2f)));
+        Assert.Equal(new PointF(3f, 2f), layer.WorldPxToGrid(world));
+    }
+
+    [Fact]
+    public void ObliqueLeft_PolygonMirrorsObliqueRight()
+    {
+        using var scene = new Scene();
+        var right = scene.AddLayer(
+            1,
+            1,
+            width: 80,
+            height: 48,
+            coordinateSystem: CoordinateSystemTypes.ObliqueRight);
+
+        var left = scene.AddLayer(
+            1,
+            1,
+            width: 80,
+            height: 48,
+            coordinateSystem: CoordinateSystemTypes.ObliqueLeft);
+
+        Assert.Equal(
+            new[]
+            {
+                new Point(0, 0),
+                new Point(40, 0),
+                new Point(80, 48),
+                new Point(40, 48)
+            },
+            right[0, 0].OutlinePointsWorld);
+
+        Assert.Equal(
+            new[]
+            {
+                new Point(40, 0),
+                new Point(80, 0),
+                new Point(40, 48),
+                new Point(0, 48)
+            },
+            left[0, 0].OutlinePointsWorld);
+    }
+
+    [Fact]
+    public void CoordinateSystemType_RoundTripsBothObliqueImplementations()
+    {
+        using var scene = new Scene();
+        var layer = scene.AddLayer(2, 2);
+
+        layer.CoordinateSystemType = CoordinateSystemTypes.ObliqueRight;
+        Assert.Equal(CoordinateSystemTypes.ObliqueRight, layer.CoordinateSystemType);
+
+        layer.CoordinateSystemType = CoordinateSystemTypes.ObliqueLeft;
+        Assert.Equal(CoordinateSystemTypes.ObliqueLeft, layer.CoordinateSystemType);
+    }
+}


### PR DESCRIPTION
- Add oblique-left scene coordinates and fix isometric-axial behavior.
- Expand coordinate system types and interfaces to support the new mapping.
- Update scene layer coordinate handling for the revised coordinate modes.
- Add tests and demo updates to cover isometric axial coordinate behavior.