### PR TITLE
fix(rendering): fix sprite cloning composition

### DIFF
--- a/Gondwana/Drawing/Sprites/CompositeSprite.cs
+++ b/Gondwana/Drawing/Sprites/CompositeSprite.cs
@@ -83,21 +83,27 @@ public class CompositeSprite : IMovableOnSceneLayer
     }
 
     /// <summary>
-    /// Gets the current position of the composite sprite based on its anchor mode.
+    /// Gets the current position of the composite sprite in scene-layer grid coordinates,
+    /// based on its anchor mode.
     /// </summary>
-    /// <returns>The position of the composite's anchor point.</returns>
+    /// <returns>The grid-space position of the composite's anchor point.</returns>
     public Vector2 GetPosition()
     {
         Rectangle r = Range;
         if (r == Rectangle.Empty)
             return Vector2.Zero;
 
-        return AnchorMode switch
+        PointF anchorWorldPx = AnchorMode switch
         {
-            CompositeAnchorMode.TopLeft => new Vector2(r.Left, r.Top),
-            CompositeAnchorMode.Center => new Vector2(r.Left + (r.Width / 2f), r.Top + (r.Height / 2f)),
-            _ => new Vector2(r.Left, r.Top)
+            CompositeAnchorMode.TopLeft => new PointF(r.Left, r.Top),
+            CompositeAnchorMode.Center => new PointF(
+                r.Left + (r.Width / 2f),
+                r.Top + (r.Height / 2f)),
+            _ => new PointF(r.Left, r.Top)
         };
+
+        PointF anchorGrid = SceneLayer.WorldPxToGrid(anchorWorldPx);
+        return new Vector2(anchorGrid.X, anchorGrid.Y);
     }
 
     /// <summary>
@@ -176,7 +182,7 @@ public class CompositeSprite : IMovableOnSceneLayer
 
     /// <summary>
     /// Add a sprite and place it by offset from the composite anchor.
-    /// Offset is interpreted relative to the CURRENT composite anchor (derived from Range).
+    /// Offset is interpreted in grid coordinates relative to the current composite anchor.
     /// </summary>
     /// <param name="sprite">The sprite to add to this composite.</param>
     /// <param name="offsetFromCompositeAnchor">The offset from the composite's anchor point.</param>

--- a/Gondwana/Drawing/Sprites/Sprite.cs
+++ b/Gondwana/Drawing/Sprites/Sprite.cs
@@ -74,12 +74,17 @@ public partial class Sprite : Tile, IMovableOnSceneLayer, ICollisionMovableEntit
     /// <summary>
     /// Copy constructor used by <see cref="SpriteManager.CloneSprite(Sprite)"/>.
     /// </summary>
-    internal Sprite(Sprite sprite)
+    internal Sprite(Sprite sprite, SceneLayer sceneLayer)
     {
-        animator = new Animator(this);
-        SpriteManager.Instance.AddSprite(this);
+        ArgumentNullException.ThrowIfNull(sprite);
 
-        _sceneLayer = sprite._sceneLayer;
+        _sceneLayer = sceneLayer
+            ?? throw new ArgumentNullException(
+                nameof(sceneLayer),
+                "Sprite must be attached to a SceneLayer.");
+
+        animator = new Animator(this);
+
         frame = sprite.frame;
         CopyCollisionSettingsFrom(sprite);
         _horizAlign = sprite._horizAlign;
@@ -102,6 +107,7 @@ public partial class Sprite : Tile, IMovableOnSceneLayer, ICollisionMovableEntit
             collidesWith: CollisionMasks.All);
 
         _sceneLayer.RefreshQueue.AddWorldRect(DrawLocationWorld);
+        SpriteManager.Instance.AddSprite(this);
     }
 
     ~Sprite()

--- a/Gondwana/Drawing/Sprites/SpriteManager.cs
+++ b/Gondwana/Drawing/Sprites/SpriteManager.cs
@@ -81,13 +81,7 @@ public sealed class SpriteManager : IDisposable
     /// <returns>The cloned sprite.</returns>
     public Sprite CloneSprite(Sprite sprite, SceneLayer sceneLayer)
     {
-        Sprite newSprite = new Sprite(sprite);
-
-        if (newSprite.SceneLayer != sceneLayer)
-        {
-            newSprite._sceneLayer = sceneLayer;
-            newSprite._sceneLayer.RefreshQueue.AddWorldRect(newSprite.DrawLocationWorld);
-        }
+        Sprite newSprite = new Sprite(sprite, sceneLayer);
 
         SpriteCreated?.Invoke(newSprite);
         return newSprite;

--- a/Testing/Gondwana.Tests/Drawing/Sprites/SpriteCompositionTests.cs
+++ b/Testing/Gondwana.Tests/Drawing/Sprites/SpriteCompositionTests.cs
@@ -1,0 +1,156 @@
+using System.Drawing;
+using System.Numerics;
+using Gondwana.Drawing;
+using Gondwana.Drawing.Coordinates;
+using Gondwana.Drawing.Sprites;
+using Gondwana.Scenes;
+
+namespace Gondwana.Tests.Drawing.Sprites;
+
+public sealed class SpriteCompositionTests : IDisposable
+{
+    private readonly List<Sprite> _sprites = new();
+    private readonly List<Scene> _scenes = new();
+
+    [Fact]
+    public void GetPosition_ReturnsCompositeAnchorInGridCoordinates()
+    {
+        SceneLayer layer = CreateLayer(
+            columns: 10,
+            rows: 10,
+            tileWidth: 32,
+            tileHeight: 16);
+
+        Sprite first = CreateSprite(layer, new Vector2(2, 3));
+        Sprite second = CreateSprite(layer, new Vector2(4, 5));
+        var composite = new CompositeSprite(first, second);
+
+        composite.AnchorMode = CompositeAnchorMode.TopLeft;
+        Assert.Equal(new Vector2(2, 3), composite.GetPosition());
+
+        composite.AnchorMode = CompositeAnchorMode.Center;
+        Assert.Equal(new Vector2(3.5f, 4.5f), composite.GetPosition());
+    }
+
+    [Fact]
+    public void SetPosition_MovesChildrenUsingGridSpace()
+    {
+        SceneLayer layer = CreateLayer(
+            columns: 12,
+            rows: 12,
+            tileWidth: 32,
+            tileHeight: 16);
+
+        Sprite first = CreateSprite(layer, new Vector2(2, 3));
+        Sprite second = CreateSprite(layer, new Vector2(4, 5));
+        var composite = new CompositeSprite(first, second);
+
+        composite.SetPosition(new Vector2(6, 7));
+
+        Assert.Equal(new Vector2(6, 7), first.GetPosition());
+        Assert.Equal(new Vector2(8, 9), second.GetPosition());
+    }
+
+    [Fact]
+    public void AddChildWithOffset_InterpretsOffsetInGridSpace()
+    {
+        SceneLayer layer = CreateLayer(
+            columns: 10,
+            rows: 10,
+            tileWidth: 32,
+            tileHeight: 16);
+
+        Sprite body = CreateSprite(layer, new Vector2(2, 3));
+        Sprite child = CreateSprite(layer, Vector2.Zero);
+        var composite = new CompositeSprite(body);
+
+        composite.AddChildWithOffset(child, new Vector2(1, -1));
+
+        Assert.Equal(new Vector2(3, 2), child.GetPosition());
+    }
+
+    [Fact]
+    public void CloneSprite_ToDifferentLayer_BindsMovementToDestinationLayer()
+    {
+        SceneLayer sourceLayer = CreateLayer(
+            columns: 10,
+            rows: 1,
+            tileWidth: 32,
+            tileHeight: 32);
+
+        SceneLayer destinationLayer = CreateLayer(
+            columns: 3,
+            rows: 1,
+            tileWidth: 32,
+            tileHeight: 32);
+
+        Sprite source = CreateSprite(sourceLayer, Vector2.Zero);
+        Sprite clone = Track(
+            SpriteManager.Instance.CloneSprite(
+                source,
+                destinationLayer));
+
+        clone.SetPosition(new Vector2(2, 0));
+        clone.Movement.WrapX = true;
+        clone.Movement.SetVelocity(new Vector2(2, 0));
+
+        clone.Movement.AdvanceMovement(1f);
+
+        Assert.Same(destinationLayer, clone.SceneLayer);
+        Assert.Equal(new Vector2(1, 0), clone.GetPosition());
+    }
+
+    public void Dispose()
+    {
+        foreach (Sprite sprite in _sprites)
+        {
+            if (SpriteManager.Instance._spriteList.Remove(sprite))
+                sprite.DisposeImmediate();
+        }
+
+        foreach (Scene scene in _scenes)
+            scene.Dispose();
+    }
+
+    private SceneLayer CreateLayer(
+        int columns,
+        int rows,
+        int tileWidth,
+        int tileHeight)
+    {
+        var scene = new Scene();
+        _scenes.Add(scene);
+
+        return scene.AddLayer(
+            columnCount: columns,
+            rowCount: rows,
+            width: tileWidth,
+            height: tileHeight,
+            zOrder: 0,
+            parallax: 1f,
+            coordinateSystem: CoordinateSystemTypes.Orthogonal);
+    }
+
+    private Sprite CreateSprite(
+        SceneLayer layer,
+        Vector2 position)
+    {
+        Sprite sprite = Track(
+            SpriteManager.Instance.CreateSprite(
+                layer,
+                default));
+
+        sprite.RenderSize = new Size(
+            layer.TileWidth,
+            layer.TileHeight);
+
+        sprite.SetPosition(position);
+        return sprite;
+    }
+
+    private Sprite Track(Sprite sprite)
+    {
+        _sprites.Add(sprite);
+        return sprite;
+    }
+}

--- a/Testing/Gondwana.Tests/Drawing/Sprites/SpriteCompositionTests.cs
+++ b/Testing/Gondwana.Tests/Drawing/Sprites/SpriteCompositionTests.cs
@@ -7,6 +7,7 @@ using Gondwana.Scenes;
 
 namespace Gondwana.Tests.Drawing.Sprites;
 
+[Collection("SpriteManager")]
 public sealed class SpriteCompositionTests : IDisposable
 {
     private readonly List<Sprite> _sprites = new();


### PR DESCRIPTION
- Fix `CloneSprite` so sprite cloning preserves composition state correctly.
- Update sprite/composite sprite handling to avoid shared or corrupted sprite data.
- Add regression tests covering sprite composition and clone behavior.