### PR TITLE
feat(core): add effect subsystem

### DIFF
--- a/Gondwana/Drawing/Direct/DirectDrawingBase.cs
+++ b/Gondwana/Drawing/Direct/DirectDrawingBase.cs
@@ -445,9 +445,16 @@ public abstract class DirectDrawingBase : IDirectDrawable, IComparable<DirectDra
     /// </remarks>
     public RectangleF GetDrawLocationScreen(View view)
     {
-        // View mode already returns _screenBounds
+        // View-mode drawings participate in View-level presentation transforms.
         if (Mode == DirectDrawingMode.View)
-            return _screenBounds;
+        {
+            PointF offset = view.GetEffectOffsetPx(layer: null);
+            return new RectangleF(
+                _screenBounds.Left + offset.X,
+                _screenBounds.Top + offset.Y,
+                _screenBounds.Width,
+                _screenBounds.Height);
+        }
 
         // translate world bounds to screen via view transform
         return view.WorldRectToScreenRect(SceneLayer!, _worldBounds);

--- a/Gondwana/Effects/DisplayEffect.cs
+++ b/Gondwana/Effects/DisplayEffect.cs
@@ -1,0 +1,151 @@
+using Gondwana.Physics.Movement.Easing;
+
+namespace Gondwana.Effects;
+
+/// <summary>
+/// Base class for transient effects applied to a View or SceneLayer.
+/// </summary>
+/// <remarks>
+/// Display effects update presentation-only state. They do not move world objects,
+/// change collision geometry, or alter a SceneLayer's canonical origin.
+/// </remarks>
+public abstract class DisplayEffect
+{
+    private EffectsManager? _owner;
+    private object? _target;
+    private float _elapsedSeconds;
+
+    private protected DisplayEffect(
+        float durationSeconds,
+        EasingKind easing = EasingKind.Linear)
+    {
+        DurationSeconds = Math.Max(0f, durationSeconds);
+        Easing = easing;
+    }
+
+    /// <summary>Occurs when the effect reaches its requested duration.</summary>
+    public event Action<DisplayEffect>? Completed;
+
+    /// <summary>Occurs when the effect is cancelled or replaced.</summary>
+    public event Action<DisplayEffect>? Cancelled;
+
+    /// <summary>Gets the effect's unique identifier.</summary>
+    public Guid Id { get; } = Guid.NewGuid();
+
+    /// <summary>Gets the requested effect duration in seconds.</summary>
+    public float DurationSeconds { get; }
+
+    /// <summary>Gets the easing curve used to transform normalized progress.</summary>
+    public EasingKind Easing { get; }
+
+    /// <summary>Gets the current lifecycle state.</summary>
+    public EffectStatus Status { get; private set; } = EffectStatus.Pending;
+
+    /// <summary>Gets the normalized, uneased progress in the range 0 through 1.</summary>
+    public float Progress { get; private set; }
+
+    internal object Target => _target
+        ?? throw new InvalidOperationException("The effect has not been started.");
+
+    internal abstract EffectChannel Channel { get; }
+
+    internal abstract bool SupportsTarget(object target);
+
+    private protected TTarget GetTarget<TTarget>() where TTarget : class =>
+        Target as TTarget
+        ?? throw new InvalidOperationException(
+            $"{GetType().Name} cannot operate on target type {Target.GetType().Name}.");
+
+    internal void StartInternal(EffectsManager owner, object target)
+    {
+        if (Status != EffectStatus.Pending)
+            throw new InvalidOperationException("An effect instance can only be started once.");
+
+        _owner = owner;
+        _target = target;
+        Status = EffectStatus.Running;
+
+        OnStarting();
+
+        if (DurationSeconds <= 0f)
+        {
+            Progress = 1f;
+            ApplyProgress(1f);
+            CompleteInternal();
+            return;
+        }
+
+        ApplyProgress(EasingFunctions.From(Easing)(0f));
+    }
+
+    internal bool AdvanceInternal(float deltaSeconds)
+    {
+        if (Status != EffectStatus.Running)
+            return true;
+
+        _elapsedSeconds = Math.Min(
+            DurationSeconds,
+            _elapsedSeconds + Math.Max(0f, deltaSeconds));
+
+        Progress = DurationSeconds <= 0f
+            ? 1f
+            : Math.Clamp(_elapsedSeconds / DurationSeconds, 0f, 1f);
+
+        float easedProgress = EasingFunctions.From(Easing)(Progress);
+        ApplyProgress(easedProgress);
+
+        if (Progress >= 1f)
+            CompleteInternal();
+
+        return Status != EffectStatus.Running;
+    }
+
+    /// <summary>
+    /// Cancels the effect and restores the presentation state that existed when it began.
+    /// </summary>
+    public void Cancel() => _owner?.Cancel(this);
+
+    internal void CancelInternal(bool restoreState)
+    {
+        if (Status != EffectStatus.Running)
+            return;
+
+        if (restoreState)
+            RestoreOriginalState();
+
+        Status = EffectStatus.Cancelled;
+        _owner = null;
+        Cancelled?.Invoke(this);
+    }
+
+    private void CompleteInternal()
+    {
+        if (Status != EffectStatus.Running)
+            return;
+
+        OnCompleted();
+        Status = EffectStatus.Completed;
+        _owner = null;
+        Completed?.Invoke(this);
+    }
+
+    private protected virtual void OnStarting()
+    {
+    }
+
+    private protected abstract void ApplyProgress(float progress);
+
+    private protected virtual void OnCompleted()
+    {
+    }
+
+    private protected abstract void RestoreOriginalState();
+}
+
+internal enum EffectChannel
+{
+    Transform,
+    Opacity,
+    Reveal,
+    Zoom
+}

--- a/Gondwana/Effects/EarthquakeEffect.cs
+++ b/Gondwana/Effects/EarthquakeEffect.cs
@@ -1,0 +1,72 @@
+using System.Drawing;
+using Gondwana.Physics.Movement.Easing;
+using Gondwana.Rendering.Views;
+
+namespace Gondwana.Effects;
+
+/// <summary>
+/// Applies a decaying, presentation-only camera shake to a View.
+/// </summary>
+public sealed class EarthquakeEffect : DisplayEffect
+{
+    private readonly Random _random;
+    private PointF _originalFactor;
+    private PointF _originalPixels;
+
+    /// <summary>Creates a camera-shake effect.</summary>
+    public EarthquakeEffect(
+        float durationSeconds,
+        float intensityPx = 8f,
+        bool decay = true,
+        int? randomSeed = null)
+        : base(durationSeconds, EasingKind.Linear)
+    {
+        if (intensityPx < 0f)
+            throw new ArgumentOutOfRangeException(nameof(intensityPx));
+
+        IntensityPx = intensityPx;
+        Decay = decay;
+        _random = new Random(randomSeed ?? Random.Shared.Next());
+    }
+
+    /// <summary>Gets the maximum shake displacement in screen pixels.</summary>
+    public float IntensityPx { get; }
+
+    /// <summary>Gets whether shake intensity falls to zero over the effect duration.</summary>
+    public bool Decay { get; }
+
+    internal override EffectChannel Channel => EffectChannel.Transform;
+
+    internal override bool SupportsTarget(object target) => target is View;
+
+    private protected override void OnStarting()
+    {
+        _originalFactor = EffectTargetAccess.GetOffsetFactor(Target);
+        _originalPixels = EffectTargetAccess.GetOffsetPixels(Target);
+        EffectTargetAccess.SetTransform(Target, PointF.Empty, PointF.Empty);
+    }
+
+    private protected override void ApplyProgress(float progress)
+    {
+        if (progress >= 1f || IntensityPx <= 0f)
+        {
+            EffectTargetAccess.SetTransform(Target, PointF.Empty, PointF.Empty);
+            return;
+        }
+
+        float amplitude = Decay
+            ? IntensityPx * (1f - progress)
+            : IntensityPx;
+
+        float x = ((float)_random.NextDouble() * 2f - 1f) * amplitude;
+        float y = ((float)_random.NextDouble() * 2f - 1f) * amplitude;
+
+        EffectTargetAccess.SetTransform(
+            Target,
+            PointF.Empty,
+            new PointF(x, y));
+    }
+
+    private protected override void RestoreOriginalState() =>
+        EffectTargetAccess.SetTransform(Target, _originalFactor, _originalPixels);
+}

--- a/Gondwana/Effects/EarthquakeEffect.cs
+++ b/Gondwana/Effects/EarthquakeEffect.cs
@@ -43,14 +43,17 @@ public sealed class EarthquakeEffect : DisplayEffect
     {
         _originalFactor = EffectTargetAccess.GetOffsetFactor(Target);
         _originalPixels = EffectTargetAccess.GetOffsetPixels(Target);
-        EffectTargetAccess.SetTransform(Target, PointF.Empty, PointF.Empty);
     }
 
     private protected override void ApplyProgress(float progress)
     {
         if (progress >= 1f || IntensityPx <= 0f)
         {
-            EffectTargetAccess.SetTransform(Target, PointF.Empty, PointF.Empty);
+            EffectTargetAccess.SetTransform(
+                Target,
+                _originalFactor,
+                _originalPixels);
+
             return;
         }
 
@@ -63,8 +66,10 @@ public sealed class EarthquakeEffect : DisplayEffect
 
         EffectTargetAccess.SetTransform(
             Target,
-            PointF.Empty,
-            new PointF(x, y));
+            _originalFactor,
+            new PointF(
+                _originalPixels.X + x,
+                _originalPixels.Y + y));
     }
 
     private protected override void RestoreOriginalState() =>

--- a/Gondwana/Effects/EffectDirection.cs
+++ b/Gondwana/Effects/EffectDirection.cs
@@ -1,0 +1,34 @@
+namespace Gondwana.Effects;
+
+/// <summary>
+/// Specifies the direction in which a directional display effect travels.
+/// </summary>
+public enum EffectDirection
+{
+    /// <summary>No direction is specified.</summary>
+    None,
+
+    /// <summary>The effect travels from the left edge toward the right edge.</summary>
+    FromLeftToRight,
+
+    /// <summary>The effect travels from the right edge toward the left edge.</summary>
+    FromRightToLeft,
+
+    /// <summary>The effect travels from the top edge toward the bottom edge.</summary>
+    FromTopToBottom,
+
+    /// <summary>The effect travels from the bottom edge toward the top edge.</summary>
+    FromBottomToTop,
+
+    /// <summary>The effect travels from the upper-left corner toward the lower-right corner.</summary>
+    FromTopLeftToBottomRight,
+
+    /// <summary>The effect travels from the upper-right corner toward the lower-left corner.</summary>
+    FromTopRightToBottomLeft,
+
+    /// <summary>The effect travels from the lower-left corner toward the upper-right corner.</summary>
+    FromBottomLeftToTopRight,
+
+    /// <summary>The effect travels from the lower-right corner toward the upper-left corner.</summary>
+    FromBottomRightToTopLeft
+}

--- a/Gondwana/Effects/EffectGeometry.cs
+++ b/Gondwana/Effects/EffectGeometry.cs
@@ -1,0 +1,44 @@
+using System.Drawing;
+
+namespace Gondwana.Effects;
+
+internal static class EffectGeometry
+{
+    internal static RectangleF GetRevealRect(
+        RectangleF bounds,
+        EffectDirection direction,
+        float progress)
+    {
+        progress = Math.Clamp(progress, 0f, 1f);
+
+        if (progress <= 0f || bounds.Width <= 0f || bounds.Height <= 0f)
+            return RectangleF.Empty;
+
+        if (progress >= 1f || direction == EffectDirection.None)
+            return bounds;
+
+        float width = bounds.Width * progress;
+        float height = bounds.Height * progress;
+
+        return direction switch
+        {
+            EffectDirection.FromLeftToRight =>
+                new RectangleF(bounds.Left, bounds.Top, width, bounds.Height),
+            EffectDirection.FromRightToLeft =>
+                new RectangleF(bounds.Right - width, bounds.Top, width, bounds.Height),
+            EffectDirection.FromTopToBottom =>
+                new RectangleF(bounds.Left, bounds.Top, bounds.Width, height),
+            EffectDirection.FromBottomToTop =>
+                new RectangleF(bounds.Left, bounds.Bottom - height, bounds.Width, height),
+            EffectDirection.FromTopLeftToBottomRight =>
+                new RectangleF(bounds.Left, bounds.Top, width, height),
+            EffectDirection.FromTopRightToBottomLeft =>
+                new RectangleF(bounds.Right - width, bounds.Top, width, height),
+            EffectDirection.FromBottomLeftToTopRight =>
+                new RectangleF(bounds.Left, bounds.Bottom - height, width, height),
+            EffectDirection.FromBottomRightToTopLeft =>
+                new RectangleF(bounds.Right - width, bounds.Bottom - height, width, height),
+            _ => bounds
+        };
+    }
+}

--- a/Gondwana/Effects/EffectStatus.cs
+++ b/Gondwana/Effects/EffectStatus.cs
@@ -1,0 +1,19 @@
+namespace Gondwana.Effects;
+
+/// <summary>
+/// Describes the current lifecycle state of a display effect.
+/// </summary>
+public enum EffectStatus
+{
+    /// <summary>The effect has been created but has not been started.</summary>
+    Pending,
+
+    /// <summary>The effect is actively advancing.</summary>
+    Running,
+
+    /// <summary>The effect reached its requested duration.</summary>
+    Completed,
+
+    /// <summary>The effect was cancelled before completing.</summary>
+    Cancelled
+}

--- a/Gondwana/Effects/EffectTargetAccess.cs
+++ b/Gondwana/Effects/EffectTargetAccess.cs
@@ -1,0 +1,105 @@
+using System.Drawing;
+using Gondwana.Rendering.Views;
+using Gondwana.Scenes;
+
+namespace Gondwana.Effects;
+
+internal static class EffectTargetAccess
+{
+    internal static float GetOpacity(object target) => target switch
+    {
+        View view => view.EffectOpacity,
+        SceneLayer layer => layer.EffectOpacity,
+        _ => throw Unsupported(target)
+    };
+
+    internal static void SetOpacity(object target, float value)
+    {
+        value = Math.Clamp(value, 0f, 1f);
+
+        switch (target)
+        {
+            case View view:
+                view.EffectOpacity = value;
+                break;
+            case SceneLayer layer:
+                layer.EffectOpacity = value;
+                break;
+            default:
+                throw Unsupported(target);
+        }
+    }
+
+    internal static float GetReveal(object target) => target switch
+    {
+        View view => view.EffectReveal,
+        SceneLayer layer => layer.EffectReveal,
+        _ => throw Unsupported(target)
+    };
+
+    internal static EffectDirection GetRevealDirection(object target) => target switch
+    {
+        View view => view.EffectRevealDirection,
+        SceneLayer layer => layer.EffectRevealDirection,
+        _ => throw Unsupported(target)
+    };
+
+    internal static void SetReveal(
+        object target,
+        float value,
+        EffectDirection direction)
+    {
+        value = Math.Clamp(value, 0f, 1f);
+
+        switch (target)
+        {
+            case View view:
+                view.EffectReveal = value;
+                view.EffectRevealDirection = direction;
+                break;
+            case SceneLayer layer:
+                layer.EffectReveal = value;
+                layer.EffectRevealDirection = direction;
+                break;
+            default:
+                throw Unsupported(target);
+        }
+    }
+
+    internal static PointF GetOffsetFactor(object target) => target switch
+    {
+        View view => view.EffectOffsetFactor,
+        SceneLayer layer => layer.EffectOffsetFactor,
+        _ => throw Unsupported(target)
+    };
+
+    internal static PointF GetOffsetPixels(object target) => target switch
+    {
+        View view => view.EffectOffsetPx,
+        SceneLayer layer => layer.EffectOffsetPx,
+        _ => throw Unsupported(target)
+    };
+
+    internal static void SetTransform(
+        object target,
+        PointF factor,
+        PointF pixels)
+    {
+        switch (target)
+        {
+            case View view:
+                view.EffectOffsetFactor = factor;
+                view.EffectOffsetPx = pixels;
+                break;
+            case SceneLayer layer:
+                layer.EffectOffsetFactor = factor;
+                layer.EffectOffsetPx = pixels;
+                break;
+            default:
+                throw Unsupported(target);
+        }
+    }
+
+    private static ArgumentException Unsupported(object target) =>
+        new($"Unsupported effect target type: {target.GetType().FullName}.", nameof(target));
+}

--- a/Gondwana/Effects/EffectsManager.cs
+++ b/Gondwana/Effects/EffectsManager.cs
@@ -1,0 +1,199 @@
+using System.Collections.ObjectModel;
+using Gondwana.Rendering;
+using Gondwana.Rendering.Views;
+using Gondwana.Scenes;
+using Gondwana.Timers;
+
+namespace Gondwana.Effects;
+
+/// <summary>
+/// Owns and advances display effects for one RenderSurfaceHost.
+/// </summary>
+public sealed class EffectsManager : IDisposable
+{
+    private readonly object _sync = new();
+    private readonly List<DisplayEffect> _activeEffects = [];
+    private readonly RenderSurfaceHostBase _host;
+    private long _lastTick = HighResTimer.GetCurrentTick();
+    private bool _disposed;
+
+    internal EffectsManager(RenderSurfaceHostBase host) =>
+        _host = host ?? throw new ArgumentNullException(nameof(host));
+
+    /// <summary>Gets a snapshot of the effects that are currently running.</summary>
+    public ReadOnlyCollection<DisplayEffect> ActiveEffects
+    {
+        get
+        {
+            lock (_sync)
+                return _activeEffects.ToList().AsReadOnly();
+        }
+    }
+
+    /// <summary>Starts an effect targeting a View owned by this render surface.</summary>
+    public TEffect Run<TEffect>(View target, TEffect effect)
+        where TEffect : DisplayEffect => RunCore(target, effect);
+
+    /// <summary>Starts an effect targeting a SceneLayer in the currently bound Scene.</summary>
+    public TEffect Run<TEffect>(SceneLayer target, TEffect effect)
+        where TEffect : DisplayEffect => RunCore(target, effect);
+
+    /// <summary>Cancels a running effect and restores its original presentation state.</summary>
+    public void Cancel(DisplayEffect effect)
+    {
+        ArgumentNullException.ThrowIfNull(effect);
+
+        bool removed;
+        lock (_sync)
+            removed = _activeEffects.Remove(effect);
+
+        if (!removed)
+            return;
+
+        effect.CancelInternal(restoreState: true);
+        Invalidate(effect.Target);
+    }
+
+    /// <summary>Cancels every running effect owned by this manager.</summary>
+    public void CancelAll()
+    {
+        DisplayEffect[] snapshot;
+
+        lock (_sync)
+        {
+            snapshot = _activeEffects.ToArray();
+            _activeEffects.Clear();
+        }
+
+        foreach (var effect in snapshot)
+        {
+            effect.CancelInternal(restoreState: true);
+            Invalidate(effect.Target);
+        }
+    }
+
+    internal void Update(long tick)
+    {
+        float deltaSeconds = HighResTimer.GetDuration(_lastTick, tick);
+        _lastTick = tick;
+        Advance(deltaSeconds);
+    }
+
+    internal void Advance(float deltaSeconds)
+    {
+        DisplayEffect[] snapshot;
+
+        lock (_sync)
+            snapshot = _activeEffects.ToArray();
+
+        foreach (var effect in snapshot)
+        {
+            if (!OwnsTarget(effect.Target))
+            {
+                RemoveAndCancel(effect, restoreState: false);
+                continue;
+            }
+
+            bool finished = effect.AdvanceInternal(deltaSeconds);
+            Invalidate(effect.Target);
+
+            if (finished)
+            {
+                lock (_sync)
+                    _activeEffects.Remove(effect);
+            }
+        }
+    }
+
+    internal void Invalidate(object target)
+    {
+        if (target is View or SceneLayer)
+            _host.Scene.FullRefreshNeeded = true;
+    }
+
+    private TEffect RunCore<TEffect>(object target, TEffect effect)
+        where TEffect : DisplayEffect
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(effect);
+
+        if (!OwnsTarget(target))
+            throw new ArgumentException(
+                "The effect target is not owned by this render surface host.",
+                nameof(target));
+
+        if (!effect.SupportsTarget(target))
+            throw new ArgumentException(
+                $"{effect.GetType().Name} does not support {target.GetType().Name} targets.",
+                nameof(effect));
+
+        DisplayEffect? replaced;
+
+        lock (_sync)
+        {
+            if (effect.Status != EffectStatus.Pending)
+                throw new InvalidOperationException("An effect instance can only be run once.");
+
+            replaced = _activeEffects.FirstOrDefault(
+                active => ReferenceEquals(active.Target, target)
+                          && active.Channel == effect.Channel);
+
+            if (replaced is not null)
+                _activeEffects.Remove(replaced);
+
+            _activeEffects.Add(effect);
+        }
+
+        // Preserve the current presentation value when replacing an effect so the
+        // new effect can continue from it without a one-frame reset.
+        replaced?.CancelInternal(restoreState: false);
+
+        try
+        {
+            effect.StartInternal(this, target);
+            Invalidate(target);
+        }
+        catch
+        {
+            lock (_sync)
+                _activeEffects.Remove(effect);
+
+            throw;
+        }
+
+        if (effect.Status != EffectStatus.Running)
+        {
+            lock (_sync)
+                _activeEffects.Remove(effect);
+        }
+
+        return effect;
+    }
+
+    private bool OwnsTarget(object target) => target switch
+    {
+        View view => _host.ViewManager.Views.Contains(view),
+        SceneLayer layer => ReferenceEquals(layer.Scene, _host.Scene)
+                            && _host.Scene.SceneLayers.Contains(layer),
+        _ => false
+    };
+
+    private void RemoveAndCancel(DisplayEffect effect, bool restoreState)
+    {
+        lock (_sync)
+            _activeEffects.Remove(effect);
+
+        effect.CancelInternal(restoreState);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        CancelAll();
+    }
+}

--- a/Gondwana/Effects/FadeEffects.cs
+++ b/Gondwana/Effects/FadeEffects.cs
@@ -1,0 +1,72 @@
+using Gondwana.Physics.Movement.Easing;
+using Gondwana.Rendering.Views;
+using Gondwana.Scenes;
+
+namespace Gondwana.Effects;
+
+/// <summary>Base implementation shared by fade-in and fade-out effects.</summary>
+public abstract class FadeEffect : DisplayEffect
+{
+    private readonly float _targetOpacity;
+    private readonly bool _startTransparentWhenOpaque;
+    private float _originalOpacity;
+    private float _startOpacity;
+
+    private protected FadeEffect(
+        float targetOpacity,
+        float durationSeconds,
+        EasingKind easing,
+        bool startTransparentWhenOpaque)
+        : base(durationSeconds, easing)
+    {
+        _targetOpacity = Math.Clamp(targetOpacity, 0f, 1f);
+        _startTransparentWhenOpaque = startTransparentWhenOpaque;
+    }
+
+    internal override EffectChannel Channel => EffectChannel.Opacity;
+
+    internal override bool SupportsTarget(object target) =>
+        target is View or SceneLayer;
+
+    private protected override void OnStarting()
+    {
+        _originalOpacity = EffectTargetAccess.GetOpacity(Target);
+        _startOpacity = _startTransparentWhenOpaque && _originalOpacity >= 0.9999f
+            ? 0f
+            : _originalOpacity;
+
+        EffectTargetAccess.SetOpacity(Target, _startOpacity);
+    }
+
+    private protected override void ApplyProgress(float progress) =>
+        EffectTargetAccess.SetOpacity(
+            Target,
+            _startOpacity + (_targetOpacity - _startOpacity) * progress);
+
+    private protected override void RestoreOriginalState() =>
+        EffectTargetAccess.SetOpacity(Target, _originalOpacity);
+}
+
+/// <summary>Fades a View or SceneLayer to fully opaque.</summary>
+public sealed class FadeInEffect : FadeEffect
+{
+    /// <summary>Creates a fade-in effect.</summary>
+    public FadeInEffect(
+        float durationSeconds,
+        EasingKind easing = EasingKind.Linear)
+        : base(1f, durationSeconds, easing, startTransparentWhenOpaque: true)
+    {
+    }
+}
+
+/// <summary>Fades a View or SceneLayer to fully transparent.</summary>
+public sealed class FadeOutEffect : FadeEffect
+{
+    /// <summary>Creates a fade-out effect.</summary>
+    public FadeOutEffect(
+        float durationSeconds,
+        EasingKind easing = EasingKind.Linear)
+        : base(0f, durationSeconds, easing, startTransparentWhenOpaque: false)
+    {
+    }
+}

--- a/Gondwana/Effects/SlideEffects.cs
+++ b/Gondwana/Effects/SlideEffects.cs
@@ -48,6 +48,7 @@ public abstract class SlideEffect : DisplayEffect
             _startFactor = IsNearlyZero(_originalFactor)
                 ? new PointF(-travel.X, -travel.Y)
                 : _originalFactor;
+
             _targetFactor = PointF.Empty;
         }
         else
@@ -56,7 +57,10 @@ public abstract class SlideEffect : DisplayEffect
             _targetFactor = travel;
         }
 
-        EffectTargetAccess.SetTransform(Target, _startFactor, PointF.Empty);
+        EffectTargetAccess.SetTransform(
+            Target,
+            _startFactor,
+            _originalPixels);
     }
 
     private protected override void ApplyProgress(float progress)
@@ -65,7 +69,11 @@ public abstract class SlideEffect : DisplayEffect
             _startFactor.X + (_targetFactor.X - _startFactor.X) * progress,
             _startFactor.Y + (_targetFactor.Y - _startFactor.Y) * progress);
 
-        EffectTargetAccess.SetTransform(Target, factor, PointF.Empty);
+        var pixels = new PointF(
+            _originalPixels.X * (1f - progress),
+            _originalPixels.Y * (1f - progress));
+
+        EffectTargetAccess.SetTransform(Target, factor, pixels);
     }
 
     private protected override void RestoreOriginalState() =>

--- a/Gondwana/Effects/SlideEffects.cs
+++ b/Gondwana/Effects/SlideEffects.cs
@@ -1,0 +1,115 @@
+using System.Drawing;
+using Gondwana.Physics.Movement.Easing;
+using Gondwana.Rendering.Views;
+using Gondwana.Scenes;
+
+namespace Gondwana.Effects;
+
+/// <summary>Base implementation shared by slide-in and slide-out effects.</summary>
+public abstract class SlideEffect : DisplayEffect
+{
+    private readonly bool _isSlideIn;
+    private PointF _originalFactor;
+    private PointF _originalPixels;
+    private PointF _startFactor;
+    private PointF _targetFactor;
+
+    private protected SlideEffect(
+        EffectDirection direction,
+        float durationSeconds,
+        EasingKind easing,
+        bool isSlideIn)
+        : base(durationSeconds, easing)
+    {
+        if (direction == EffectDirection.None)
+            throw new ArgumentOutOfRangeException(nameof(direction));
+
+        Direction = direction;
+        _isSlideIn = isSlideIn;
+    }
+
+    /// <summary>Gets the direction in which the target travels.</summary>
+    public EffectDirection Direction { get; }
+
+    internal override EffectChannel Channel => EffectChannel.Transform;
+
+    internal override bool SupportsTarget(object target) =>
+        target is View or SceneLayer;
+
+    private protected override void OnStarting()
+    {
+        _originalFactor = EffectTargetAccess.GetOffsetFactor(Target);
+        _originalPixels = EffectTargetAccess.GetOffsetPixels(Target);
+
+        PointF travel = GetTravelFactor(Direction);
+
+        if (_isSlideIn)
+        {
+            _startFactor = IsNearlyZero(_originalFactor)
+                ? new PointF(-travel.X, -travel.Y)
+                : _originalFactor;
+            _targetFactor = PointF.Empty;
+        }
+        else
+        {
+            _startFactor = _originalFactor;
+            _targetFactor = travel;
+        }
+
+        EffectTargetAccess.SetTransform(Target, _startFactor, PointF.Empty);
+    }
+
+    private protected override void ApplyProgress(float progress)
+    {
+        var factor = new PointF(
+            _startFactor.X + (_targetFactor.X - _startFactor.X) * progress,
+            _startFactor.Y + (_targetFactor.Y - _startFactor.Y) * progress);
+
+        EffectTargetAccess.SetTransform(Target, factor, PointF.Empty);
+    }
+
+    private protected override void RestoreOriginalState() =>
+        EffectTargetAccess.SetTransform(Target, _originalFactor, _originalPixels);
+
+    private static bool IsNearlyZero(PointF value) =>
+        Math.Abs(value.X) < 0.0001f && Math.Abs(value.Y) < 0.0001f;
+
+    private static PointF GetTravelFactor(EffectDirection direction) => direction switch
+    {
+        EffectDirection.FromLeftToRight => new PointF(1f, 0f),
+        EffectDirection.FromRightToLeft => new PointF(-1f, 0f),
+        EffectDirection.FromTopToBottom => new PointF(0f, 1f),
+        EffectDirection.FromBottomToTop => new PointF(0f, -1f),
+        EffectDirection.FromTopLeftToBottomRight => new PointF(1f, 1f),
+        EffectDirection.FromTopRightToBottomLeft => new PointF(-1f, 1f),
+        EffectDirection.FromBottomLeftToTopRight => new PointF(1f, -1f),
+        EffectDirection.FromBottomRightToTopLeft => new PointF(-1f, -1f),
+        _ => throw new ArgumentOutOfRangeException(nameof(direction))
+    };
+}
+
+/// <summary>Slides a View or SceneLayer into its normal presentation position.</summary>
+public sealed class SlideInEffect : SlideEffect
+{
+    /// <summary>Creates a slide-in effect.</summary>
+    public SlideInEffect(
+        EffectDirection direction,
+        float durationSeconds,
+        EasingKind easing = EasingKind.EaseOutCubic)
+        : base(direction, durationSeconds, easing, isSlideIn: true)
+    {
+    }
+}
+
+/// <summary>Slides a View or SceneLayer out of its normal presentation position.</summary>
+public sealed class SlideOutEffect : SlideEffect
+{
+    /// <summary>Creates a slide-out effect.</summary>
+    public SlideOutEffect(
+        EffectDirection direction,
+        float durationSeconds,
+        EasingKind easing = EasingKind.EaseInCubic)
+        : base(direction, durationSeconds, easing, isSlideIn: false)
+    {
+    }
+}

--- a/Gondwana/Effects/WipeEffects.cs
+++ b/Gondwana/Effects/WipeEffects.cs
@@ -1,0 +1,91 @@
+using Gondwana.Physics.Movement.Easing;
+using Gondwana.Rendering.Views;
+using Gondwana.Scenes;
+
+namespace Gondwana.Effects;
+
+/// <summary>Base implementation shared by directional fill and erase effects.</summary>
+public abstract class WipeEffect : DisplayEffect
+{
+    private readonly bool _isFill;
+    private float _originalReveal;
+    private EffectDirection _originalDirection;
+    private float _startReveal;
+    private float _targetReveal;
+
+    private protected WipeEffect(
+        EffectDirection direction,
+        float durationSeconds,
+        EasingKind easing,
+        bool isFill)
+        : base(durationSeconds, easing)
+    {
+        if (direction == EffectDirection.None)
+            throw new ArgumentOutOfRangeException(nameof(direction));
+
+        Direction = direction;
+        _isFill = isFill;
+    }
+
+    /// <summary>Gets the direction in which the wipe travels.</summary>
+    public EffectDirection Direction { get; }
+
+    internal override EffectChannel Channel => EffectChannel.Reveal;
+
+    internal override bool SupportsTarget(object target) =>
+        target is View or SceneLayer;
+
+    private protected override void OnStarting()
+    {
+        _originalReveal = EffectTargetAccess.GetReveal(Target);
+        _originalDirection = EffectTargetAccess.GetRevealDirection(Target);
+
+        if (_isFill)
+        {
+            _startReveal = _originalReveal >= 0.9999f ? 0f : _originalReveal;
+            _targetReveal = 1f;
+        }
+        else
+        {
+            _startReveal = _originalReveal;
+            _targetReveal = 0f;
+        }
+
+        EffectTargetAccess.SetReveal(Target, _startReveal, Direction);
+    }
+
+    private protected override void ApplyProgress(float progress) =>
+        EffectTargetAccess.SetReveal(
+            Target,
+            _startReveal + (_targetReveal - _startReveal) * progress,
+            Direction);
+
+    private protected override void RestoreOriginalState() =>
+        EffectTargetAccess.SetReveal(Target, _originalReveal, _originalDirection);
+}
+
+/// <summary>Directionally reveals a View or SceneLayer.</summary>
+public sealed class FillEffect : WipeEffect
+{
+    /// <summary>Creates a directional fill effect.</summary>
+    public FillEffect(
+        EffectDirection direction,
+        float durationSeconds,
+        EasingKind easing = EasingKind.Linear)
+        : base(direction, durationSeconds, easing, isFill: true)
+    {
+    }
+}
+
+/// <summary>Directionally removes a View or SceneLayer from presentation.</summary>
+public sealed class EraseEffect : WipeEffect
+{
+    /// <summary>Creates a directional erase effect.</summary>
+    public EraseEffect(
+        EffectDirection direction,
+        float durationSeconds,
+        EasingKind easing = EasingKind.Linear)
+        : base(direction, durationSeconds, easing, isFill: false)
+    {
+    }
+}

--- a/Gondwana/Effects/ZoomEffects.cs
+++ b/Gondwana/Effects/ZoomEffects.cs
@@ -1,0 +1,67 @@
+using Gondwana.Physics.Movement.Easing;
+using Gondwana.Rendering.Views;
+
+namespace Gondwana.Effects;
+
+/// <summary>Base implementation shared by zoom-in and zoom-out effects.</summary>
+public abstract class ZoomEffect : DisplayEffect
+{
+    private float _originalZoom;
+    private float _clampedTargetZoom;
+
+    private protected ZoomEffect(float targetZoom, float durationSeconds)
+        : base(durationSeconds, EasingKind.Linear)
+    {
+        if (targetZoom <= 0f)
+            throw new ArgumentOutOfRangeException(nameof(targetZoom));
+
+        TargetZoom = targetZoom;
+    }
+
+    /// <summary>Gets the requested final zoom factor.</summary>
+    public float TargetZoom { get; }
+
+    internal override EffectChannel Channel => EffectChannel.Zoom;
+
+    internal override bool SupportsTarget(object target) => target is View;
+
+    private protected override void OnStarting()
+    {
+        var view = GetTarget<View>();
+        _originalZoom = view.Viewport.Zoom;
+        _clampedTargetZoom = Math.Clamp(TargetZoom, view.MinZoom, view.MaxZoom);
+        view.Viewport.ZoomToOverDuration(_clampedTargetZoom, DurationSeconds);
+    }
+
+    // View.Update() advances the existing Viewport zoom animator. The effect
+    // manager owns only lifecycle, replacement, and completion notification.
+    private protected override void ApplyProgress(float progress)
+    {
+    }
+
+    private protected override void OnCompleted() =>
+        GetTarget<View>().Viewport.SnapZoom(_clampedTargetZoom);
+
+    private protected override void RestoreOriginalState() =>
+        GetTarget<View>().Viewport.SnapZoom(_originalZoom);
+}
+
+/// <summary>Animates a View to a larger or otherwise explicitly supplied zoom factor.</summary>
+public sealed class ZoomInEffect : ZoomEffect
+{
+    /// <summary>Creates a zoom-in effect.</summary>
+    public ZoomInEffect(float targetZoom, float durationSeconds)
+        : base(targetZoom, durationSeconds)
+    {
+    }
+}
+
+/// <summary>Animates a View to a smaller or otherwise explicitly supplied zoom factor.</summary>
+public sealed class ZoomOutEffect : ZoomEffect
+{
+    /// <summary>Creates a zoom-out effect.</summary>
+    public ZoomOutEffect(float targetZoom, float durationSeconds)
+        : base(targetZoom, durationSeconds)
+    {
+    }
+}

--- a/Gondwana/Engine.cs
+++ b/Gondwana/Engine.cs
@@ -887,6 +887,10 @@ public sealed class Engine : IDisposable
         // raise event
         BeforeFrameRender?.Invoke();
 
+        // Effects are presentation state, so advance them on the foreground/render cadence.
+        foreach (var surface in RenderSurfaceHostRegistry.All)
+            surface.Effects.Update(tick);
+
         // update the DirectDrawing instances' states
         DirectDrawingManager.Instance.UpdateAll(tick);
 

--- a/Gondwana/Rendering/RenderSurfaceHost.cs
+++ b/Gondwana/Rendering/RenderSurfaceHost.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using SkiaSharp;
 using Gondwana.Drawing.Direct;
+using Gondwana.Effects;
 using Gondwana.Extensibility;
 using Gondwana.Rendering.Backbuffers;
 using Gondwana.Rendering.Views;
@@ -343,6 +344,11 @@ public sealed class RenderSurfaceHost<TBackbuffer> : RenderSurfaceHostBase
             return;
         }
 
+        // A single clear lets translucent, wiped, or translated views reveal the
+        // views beneath them. Each view paints its own background as part of its
+        // presentation group below.
+        Backbuffer.ClearRect(new Rectangle(0, 0, Backbuffer.Width, Backbuffer.Height));
+
         foreach (var view in ViewManager.Views)
         {
             RenderContext.Push(view, tick);
@@ -362,35 +368,61 @@ public sealed class RenderSurfaceHost<TBackbuffer> : RenderSurfaceHostBase
 
                 foreach (var blocker in ViewManager.GetViewsAbove(view))
                 {
+                    if (!blocker.BlocksViewsBelow)
+                        continue;
+
                     var overlap = Rectangle.Intersect(vp, blocker.Viewport.TargetRectPx);
                     if (!overlap.IsEmpty)
                         Backbuffer.Canvas.ClipRect(overlap.ToSKRect(), SKClipOperation.Difference, antialias: false);
                 }
 
-                // 3) Clear the full viewport.
-                Backbuffer.ClearRect(vp);
+                int viewPresentation = BeginPresentation(
+                    view.GetPresentationBoundsPx(),
+                    view.EffectOpacity,
+                    view.EffectReveal,
+                    view.EffectRevealDirection);
 
-                // 4) Render every visible layer for the full viewport extent (layers are drawn
-                //    back-to-front by ascending Z-order, which VisibleSceneLayers already provides).
-                var sceneLayers = Scene.VisibleSceneLayers;
-
-                for (int i = 0; i < sceneLayers.Count; i++)
+                if (viewPresentation > 0)
                 {
-                    var layer = sceneLayers[i];
+                    // The view background belongs inside the group so it fades,
+                    // wipes, and slides with the rest of the view.
+                    Backbuffer.ClearRect(view.GetPresentationBoundsPx().ToPixelAlignedRect());
 
-                    // Compute the world-space rect visible through this viewport for this layer,
-                    // expanded by one tile in each direction to cover boundary rounding.
-                    var layerWorldRectF = view.ScreenRectToWorldRect(layer, vp);
-                    layerWorldRectF.Inflate(layer.TileWidth, layer.TileHeight);
-                    var layerWorldRect = layerWorldRectF.ToPixelAlignedRect();
+                    // 4) Render every visible layer for the full viewport extent (layers are drawn
+                    //    back-to-front by ascending Z-order, which VisibleSceneLayers already provides).
+                    var sceneLayers = Scene.VisibleSceneLayers;
 
-                    var drawables = layer.GetDrawablesInWorldRect(layerWorldRect);
-                    Backbuffer.DrawDrawables(view, drawables, vp);
+                    for (int i = 0; i < sceneLayers.Count; i++)
+                    {
+                        var layer = sceneLayers[i];
+
+                        int layerPresentation = BeginPresentation(
+                            GetLayerPresentationBounds(view, layer),
+                            layer.EffectOpacity,
+                            layer.EffectReveal,
+                            layer.EffectRevealDirection);
+
+                        if (layerPresentation == 0)
+                            continue;
+
+                        // Compute the world-space rect visible through this viewport for this layer,
+                        // expanded by one tile in each direction to cover boundary rounding.
+                        var layerWorldRectF = view.ScreenRectToWorldRect(layer, vp);
+                        layerWorldRectF.Inflate(layer.TileWidth, layer.TileHeight);
+                        var layerWorldRect = layerWorldRectF.ToPixelAlignedRect();
+
+                        var drawables = layer.GetDrawablesInWorldRect(layerWorldRect);
+                        Backbuffer.DrawDrawables(view, drawables, vp);
+
+                        EndPresentation(layerPresentation);
+                    }
+
+                    // 5) Render view-based DirectDrawings on top.
+                    for (int i = 0; i < overlays.Count; i++)
+                        overlays[i].Draw(Backbuffer, overlays[i].GetDrawLocationScreen(view));
+
+                    EndPresentation(viewPresentation);
                 }
-
-                // 5) Render view-based DirectDrawings on top.
-                for (int i = 0; i < overlays.Count; i++)
-                    overlays[i].Draw(Backbuffer, overlays[i].GetDrawLocationScreen(view));
 
                 Backbuffer.Canvas.Restore();
             }
@@ -452,6 +484,8 @@ public sealed class RenderSurfaceHost<TBackbuffer> : RenderSurfaceHostBase
             return;
         }
 
+        bool fullViewComposition = ViewManager.Views.Any(view => view.HasPresentationEffect);
+
         // 0) If there are no visible SceneLayers, just clear and publish the full frame.
         if (Scene.CountOfVisibleLayers == 0)
         {
@@ -462,7 +496,7 @@ public sealed class RenderSurfaceHost<TBackbuffer> : RenderSurfaceHostBase
         {
             // 1) Handle full scene refresh once (camera moved, zoom changed, etc.): clear and mark all layers as dirty.
             //    This already clears the whole backbuffer and enqueues a full rect per layer.
-            if (Scene.FullRefreshNeeded)
+            if (Scene.FullRefreshNeeded || (fullViewComposition && Scene.IsDirty))
             {
                 // this will mark the Scene.IsDirty flag as true
                 EnqueueFullSceneRefresh();
@@ -477,6 +511,9 @@ public sealed class RenderSurfaceHost<TBackbuffer> : RenderSurfaceHostBase
                 }
             }
         }
+
+        if (fullViewComposition)
+            Backbuffer.ClearRect(new Rectangle(0, 0, Backbuffer.Width, Backbuffer.Height));
 
         // 2) Render all views to Backbuffer. Draw layers back -> front (ascending Z).
         foreach (var view in ViewManager.Views)
@@ -506,27 +543,58 @@ public sealed class RenderSurfaceHost<TBackbuffer> : RenderSurfaceHostBase
                 // clip exclusive to higher Z-order views
                 foreach (var blocker in ViewManager.GetViewsAbove(view))
                 {
+                    if (!blocker.BlocksViewsBelow)
+                        continue;
+
                     var overlap = Rectangle.Intersect(vp, blocker.Viewport.TargetRectPx);
                     if (!overlap.IsEmpty)
                         Backbuffer.Canvas.ClipRect(overlap.ToSKRect(), SKClipOperation.Difference, antialias: false);
                 }
 
-                // 2.4) Pre-clear dirty areas on backbuffer to Backbuffer.ClearColor
-                PreclearScreenAreas(view, dirtyScreenRects);
+                int viewPresentation = BeginPresentation(
+                    view.GetPresentationBoundsPx(),
+                    view.EffectOpacity,
+                    view.EffectReveal,
+                    view.EffectRevealDirection);
 
-                // 2.5) Render each visible layer's dirty regions for this view
-                //      this will draw SceneLayerTiles, Sprites, and SceneLayer-based DirectDrawings
-                var sceneLayers = Scene.VisibleSceneLayers;
-
-                for (int i = 0; i < sceneLayers.Count; i++)
+                if (viewPresentation > 0)
                 {
-                    var layer = sceneLayers[i];
-                    RenderLayerDirtyRegions(view, layer);
-                }
+                    if (fullViewComposition)
+                    {
+                        Backbuffer.ClearRect(view.GetPresentationBoundsPx().ToPixelAlignedRect());
+                    }
+                    else
+                    {
+                        // 2.4) Pre-clear dirty areas on backbuffer to Backbuffer.ClearColor
+                        PreclearScreenAreas(view, dirtyScreenRects);
+                    }
 
-                // 2.6) draw all View-based DirectDrawings for this view
-                for (int i = 0; i < overlays.Count; i++)
-                    overlays[i].Draw(Backbuffer, overlays[i].GetDrawLocationScreen(view));
+                    // 2.5) Render each visible layer's dirty regions for this view
+                    //      this will draw SceneLayerTiles, Sprites, and SceneLayer-based DirectDrawings
+                    var sceneLayers = Scene.VisibleSceneLayers;
+
+                    for (int i = 0; i < sceneLayers.Count; i++)
+                    {
+                        var layer = sceneLayers[i];
+                        int layerPresentation = BeginPresentation(
+                            GetLayerPresentationBounds(view, layer),
+                            layer.EffectOpacity,
+                            layer.EffectReveal,
+                            layer.EffectRevealDirection);
+
+                        if (layerPresentation == 0)
+                            continue;
+
+                        RenderLayerDirtyRegions(view, layer);
+                        EndPresentation(layerPresentation);
+                    }
+
+                    // 2.6) draw all View-based DirectDrawings for this view
+                    for (int i = 0; i < overlays.Count; i++)
+                        overlays[i].Draw(Backbuffer, overlays[i].GetDrawLocationScreen(view));
+
+                    EndPresentation(viewPresentation);
+                }
 
                 // 2.7) Restore from viewport clip
                 Backbuffer.Canvas.Restore();
@@ -663,6 +731,62 @@ public sealed class RenderSurfaceHost<TBackbuffer> : RenderSurfaceHostBase
 
             Backbuffer.DrawDrawables(view, drawables, screenRect);
         }
+    }
+
+    private int BeginPresentation(
+        RectangleF bounds,
+        float opacity,
+        float reveal,
+        EffectDirection direction)
+    {
+        opacity = Math.Clamp(opacity, 0f, 1f);
+        reveal = Math.Clamp(reveal, 0f, 1f);
+
+        if (opacity <= 0.0001f || reveal <= 0.0001f || bounds.IsEmpty)
+            return 0;
+
+        int saveCount = 1;
+        Backbuffer.Canvas.Save();
+
+        if (reveal < 0.9999f)
+        {
+            RectangleF revealRect = EffectGeometry.GetRevealRect(bounds, direction, reveal);
+            Backbuffer.Canvas.ClipRect(
+                revealRect.ToSKRect(),
+                SKClipOperation.Intersect,
+                antialias: false);
+        }
+
+        if (opacity < 0.9999f)
+        {
+            using var paint = new SKPaint
+            {
+                Color = new SKColor(255, 255, 255, (byte)Math.Round(opacity * 255f))
+            };
+
+            Backbuffer.Canvas.SaveLayer(bounds.ToSKRect(), paint);
+            saveCount++;
+        }
+
+        return saveCount;
+    }
+
+    private void EndPresentation(int saveCount)
+    {
+        while (saveCount-- > 0)
+            Backbuffer.Canvas.Restore();
+    }
+
+    private static RectangleF GetLayerPresentationBounds(View view, SceneLayer layer)
+    {
+        RectangleF viewport = view.Viewport.TargetRectPx;
+        PointF offset = view.GetEffectOffsetPx(layer);
+
+        return new RectangleF(
+            viewport.Left + offset.X,
+            viewport.Top + offset.Y,
+            viewport.Width,
+            viewport.Height);
     }
 
     #endregion DrawRefreshQueueToBackbuffer helpers

--- a/Gondwana/Rendering/RenderSurfaceHostBase.cs
+++ b/Gondwana/Rendering/RenderSurfaceHostBase.cs
@@ -1,4 +1,5 @@
-﻿using Gondwana.Rendering.Backbuffers;
+﻿using Gondwana.Effects;
+using Gondwana.Rendering.Backbuffers;
 using Gondwana.Rendering.Views;
 using Gondwana.Scenes;
 using Gondwana.Timers;
@@ -20,7 +21,11 @@ public abstract class RenderSurfaceHostBase : IDisposable
     /// Registration ensures the render surface host is tracked for lifecycle management and can be
     /// enumerated by other system components.
     /// </remarks>
-    protected RenderSurfaceHostBase() => RenderSurfaceHostRegistry.Register(this);
+    protected RenderSurfaceHostBase()
+    {
+        Effects = new EffectsManager(this);
+        RenderSurfaceHostRegistry.Register(this);
+    }
 
     /// <summary>
     /// Finalizes an instance of the <see cref="RenderSurfaceHostBase"/> class, ensuring resources
@@ -56,6 +61,11 @@ public abstract class RenderSurfaceHostBase : IDisposable
     /// multiple views with independent cameras and viewports.
     /// </remarks>
     public abstract ViewManager ViewManager { get; }
+
+    /// <summary>
+    /// Gets the manager that owns presentation effects for this render surface.
+    /// </summary>
+    public EffectsManager Effects { get; }
 
     /// <summary>
     /// Renders the current scene frame on the GL thread and returns a snapshot of the GPU backbuffer
@@ -146,5 +156,11 @@ public abstract class RenderSurfaceHostBase : IDisposable
     /// this method to release additional resources but must call the base implementation to ensure
     /// proper unregistration.
     /// </remarks>
-    protected virtual void Dispose(bool disposing) => RenderSurfaceHostRegistry.Unregister(this);
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+            Effects.Dispose();
+
+        RenderSurfaceHostRegistry.Unregister(this);
+    }
 }

--- a/Gondwana/Rendering/Views/View.cs
+++ b/Gondwana/Rendering/Views/View.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+using Gondwana.Effects;
 using Gondwana.Logging;
 using Gondwana.Scenes;
 using Microsoft.Extensions.Logging;
@@ -59,6 +60,24 @@ public sealed class View
     /// Gets or sets the maximum zoom level allowed for this View.
     /// </summary>
     public float MaxZoom { get; set; } = 8f;
+
+    // Presentation-only state owned by EffectsManager. These values never alter
+    // camera, viewport, world, or collision state.
+    internal float EffectOpacity { get; set; } = 1f;
+    internal float EffectReveal { get; set; } = 1f;
+    internal EffectDirection EffectRevealDirection { get; set; } = EffectDirection.FromLeftToRight;
+    internal PointF EffectOffsetFactor { get; set; } = PointF.Empty;
+    internal PointF EffectOffsetPx { get; set; } = PointF.Empty;
+
+    internal bool HasPresentationEffect =>
+        EffectOpacity < 0.9999f
+        || EffectReveal < 0.9999f
+        || Math.Abs(EffectOffsetFactor.X) > 0.0001f
+        || Math.Abs(EffectOffsetFactor.Y) > 0.0001f
+        || Math.Abs(EffectOffsetPx.X) > 0.0001f
+        || Math.Abs(EffectOffsetPx.Y) > 0.0001f;
+
+    internal bool BlocksViewsBelow => !HasPresentationEffect;
 
     internal View(Camera cam, Viewport vp)
     {
@@ -152,13 +171,17 @@ public sealed class View
             ? Viewport.Zoom
             : 1f;
 
+        PointF effectOffset = GetEffectOffsetPx(layer);
+
         float offsetX =
             Viewport.TargetRectPx.Left
-            + Viewport.ScreenOffsetPx.X;
+            + Viewport.ScreenOffsetPx.X
+            + effectOffset.X;
 
         float offsetY =
             Viewport.TargetRectPx.Top
-            + Viewport.ScreenOffsetPx.Y;
+            + Viewport.ScreenOffsetPx.Y
+            + effectOffset.Y;
 
         float parallax = layer.Parallax;
         if (Math.Abs(parallax) < 1e-6f)
@@ -211,8 +234,9 @@ public sealed class View
     public PointF ScreenPxToWorldPx(SceneLayer layer, PointF screenPx)
     {
         float zoom = Viewport.Zoom <= 0f ? 1f : Viewport.Zoom;
-        float offsetX = Viewport.TargetRectPx.Left + Viewport.ScreenOffsetPx.X;
-        float offsetY = Viewport.TargetRectPx.Top + Viewport.ScreenOffsetPx.Y;
+        PointF effectOffset = GetEffectOffsetPx(layer);
+        float offsetX = Viewport.TargetRectPx.Left + Viewport.ScreenOffsetPx.X + effectOffset.X;
+        float offsetY = Viewport.TargetRectPx.Top + Viewport.ScreenOffsetPx.Y + effectOffset.Y;
         float parallax = layer.Parallax;
 
         float worldX = Camera.PositionPx.X * parallax
@@ -247,8 +271,9 @@ public sealed class View
     public PointF WorldPxToScreenPx(SceneLayer layer, PointF worldPx)
     {
         float zoom = Viewport.Zoom <= 0f ? 1f : Viewport.Zoom;
-        float offsetX = Viewport.TargetRectPx.Left + Viewport.ScreenOffsetPx.X;
-        float offsetY = Viewport.TargetRectPx.Top + Viewport.ScreenOffsetPx.Y;
+        PointF effectOffset = GetEffectOffsetPx(layer);
+        float offsetX = Viewport.TargetRectPx.Left + Viewport.ScreenOffsetPx.X + effectOffset.X;
+        float offsetY = Viewport.TargetRectPx.Top + Viewport.ScreenOffsetPx.Y + effectOffset.Y;
         float parallax = layer.Parallax;
 
         float screenX = offsetX + (worldPx.X - Camera.PositionPx.X * parallax) * zoom;
@@ -288,8 +313,9 @@ public sealed class View
 
         float zoom = Viewport.Zoom <= 0f ? 1f : Viewport.Zoom;
 
-        float offsetX = Viewport.TargetRectPx.Left + Viewport.ScreenOffsetPx.X;
-        float offsetY = Viewport.TargetRectPx.Top + Viewport.ScreenOffsetPx.Y;
+        PointF effectOffset = GetEffectOffsetPx(layer);
+        float offsetX = Viewport.TargetRectPx.Left + Viewport.ScreenOffsetPx.X + effectOffset.X;
+        float offsetY = Viewport.TargetRectPx.Top + Viewport.ScreenOffsetPx.Y + effectOffset.Y;
 
         float parallax = layer.Parallax;
 
@@ -323,8 +349,9 @@ public sealed class View
 
         float zoom = Viewport.Zoom <= 0f ? 1f : Viewport.Zoom;
 
-        float offsetX = Viewport.TargetRectPx.Left + Viewport.ScreenOffsetPx.X;
-        float offsetY = Viewport.TargetRectPx.Top + Viewport.ScreenOffsetPx.Y;
+        PointF effectOffset = GetEffectOffsetPx(layer);
+        float offsetX = Viewport.TargetRectPx.Left + Viewport.ScreenOffsetPx.X + effectOffset.X;
+        float offsetY = Viewport.TargetRectPx.Top + Viewport.ScreenOffsetPx.Y + effectOffset.Y;
 
         float parallax = layer.Parallax;
 
@@ -340,6 +367,38 @@ public sealed class View
         float worldHeight = screenRect.Height / zoom;
 
         return new RectangleF(worldLeft, worldTop, worldWidth, worldHeight);
+    }
+
+    internal PointF GetEffectOffsetPx(SceneLayer? layer)
+    {
+        PointF factor = EffectOffsetFactor;
+        PointF pixels = EffectOffsetPx;
+
+        if (layer is not null)
+        {
+            factor = new PointF(
+                factor.X + layer.EffectOffsetFactor.X,
+                factor.Y + layer.EffectOffsetFactor.Y);
+            pixels = new PointF(
+                pixels.X + layer.EffectOffsetPx.X,
+                pixels.Y + layer.EffectOffsetPx.Y);
+        }
+
+        return new PointF(
+            pixels.X + factor.X * Viewport.TargetRectPx.Width,
+            pixels.Y + factor.Y * Viewport.TargetRectPx.Height);
+    }
+
+    internal RectangleF GetPresentationBoundsPx()
+    {
+        PointF offset = GetEffectOffsetPx(layer: null);
+        RectangleF viewport = Viewport.TargetRectPx;
+
+        return new RectangleF(
+            viewport.Left + offset.X,
+            viewport.Top + offset.Y,
+            viewport.Width,
+            viewport.Height);
     }
 
     #endregion Coordinate conversion methods

--- a/Gondwana/Scenes/SceneLayer.cs
+++ b/Gondwana/Scenes/SceneLayer.cs
@@ -5,6 +5,7 @@ using Gondwana.Drawing;
 using Gondwana.Drawing.Coordinates;
 using Gondwana.Drawing.Direct;
 using Gondwana.Drawing.Sprites;
+using Gondwana.Effects;
 using Gondwana.Physics.Collisions;
 using Gondwana.Rendering;
 using Newtonsoft.Json;
@@ -137,6 +138,21 @@ public class SceneLayer : IEnumerable<SceneLayerTile>, IDisposable
     private int _tileHeight;    // rendered height
     private bool _visible;      // is SceneLayer to be rendered; useful with multiple layers
     private string _defaultTileCollisionProfile = CollisionProfileNames.World;
+
+    [JsonIgnore]
+    internal float EffectOpacity { get; set; } = 1f;
+
+    [JsonIgnore]
+    internal float EffectReveal { get; set; } = 1f;
+
+    [JsonIgnore]
+    internal EffectDirection EffectRevealDirection { get; set; } = EffectDirection.FromLeftToRight;
+
+    [JsonIgnore]
+    internal PointF EffectOffsetFactor { get; set; } = PointF.Empty;
+
+    [JsonIgnore]
+    internal PointF EffectOffsetPx { get; set; } = PointF.Empty;
 
     #endregion private fields
 
@@ -803,6 +819,11 @@ public class SceneLayer : IEnumerable<SceneLayerTile>, IDisposable
         _visible = true;
 
         _originPx = Point.Empty;                  // layer world origin
+        EffectOpacity = 1f;
+        EffectReveal = 1f;
+        EffectRevealDirection = EffectDirection.FromLeftToRight;
+        EffectOffsetFactor = PointF.Empty;
+        EffectOffsetPx = PointF.Empty;
 
         CoordinateSystemType = coordinateSystem;
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Gondwana is deliberately an engine and framework, not an all-encompassing visual
 - **Backbuffer abstraction** through `BitmapBackbuffer` and `GpuBackbuffer`
 - **WinForms, Avalonia, and Blazor adapters**, with ready-to-use hosts for Windows, Linux, macOS, and WebAssembly
 - **View-centric layered scenes** with multiple cameras, viewports, parallax, stable z-ordering, and world-space dirty-region tracking
+- **Host-owned display effects** for view- or layer-level fades, slides, directional fills/erases, view shake, and view zoom
 - **Multiple coordinate systems**: orthogonal, rhombic isometric, axial isometric, flat-top hex, pointy-top hex, and oblique
 - **Sprites and DirectDrawing** for reusable images, shapes, text, particles, overlays, effects, composites, and high-volume bitmap instances
 - **Reusable game UI widgets** with lifecycle events, automatic input registration, focus, keyboard and pointer routing, dragging, hit testing, and components such as `SplashScreen`
@@ -90,6 +91,25 @@ Gondwana is deliberately an engine and framework, not an all-encompassing visual
 - **Asset support** for tilesheets, sprites, fonts, audio, and packaged Gondwana asset files
 - **Unified keyboard, mouse, touch, and gamepad input**, with SDL2 gamepad support available as a dedicated package
 - **Audio, MIDI, browser audio, and experimental video integration** through optional packages
+
+---
+
+## Display effects
+
+Each render surface exposes an `EffectsManager` through `RenderSurfaceHostBase.Effects`:
+
+```csharp
+surface.Effects.Run(view, new FadeOutEffect(0.5f));
+surface.Effects.Run(layer, new SlideInEffect(
+    EffectDirection.FromLeftToRight,
+    durationSeconds: 0.75f));
+surface.Effects.Run(view, new EarthquakeEffect(0.4f, intensityPx: 10f));
+```
+
+Fade, slide, fill, and erase effects can target either a `View` or a `SceneLayer`.
+Earthquake and zoom effects target a `View`. Transform, opacity, reveal, and zoom
+are independent channels and can run together; starting a new effect on the same
+target and channel replaces the effect already running there.
 
 ---
 

--- a/Testing/Gondwana.Tests/Effects/EffectsManagerTests.cs
+++ b/Testing/Gondwana.Tests/Effects/EffectsManagerTests.cs
@@ -1,0 +1,236 @@
+using System.Drawing;
+using Gondwana.Effects;
+using Gondwana.Physics.Movement.Easing;
+using Gondwana.Rendering.Views;
+using Gondwana.Scenes;
+
+namespace Gondwana.Tests.Effects;
+
+public sealed class EffectsManagerTests
+{
+    [Fact]
+    public void FadeOut_View_AdvancesAndCompletes()
+    {
+        using var host = CreateHost(out View view, out _);
+        host.Scene.FullRefreshNeeded = false;
+
+        var effect = host.Effects.Run(view, new FadeOutEffect(1f));
+
+        Assert.Equal(EffectStatus.Running, effect.Status);
+        Assert.Single(host.Effects.ActiveEffects);
+        Assert.True(host.Scene.FullRefreshNeeded);
+
+        host.Effects.Advance(0.5f);
+
+        Assert.Equal(0.5f, view.EffectOpacity, 3);
+        Assert.Equal(0.5f, effect.Progress, 3);
+
+        host.Effects.Advance(0.5f);
+
+        Assert.Equal(EffectStatus.Completed, effect.Status);
+        Assert.Equal(0f, view.EffectOpacity);
+        Assert.Empty(host.Effects.ActiveEffects);
+    }
+
+    [Fact]
+    public void FadeOut_SceneLayer_DoesNotChangeViewOpacity()
+    {
+        using var host = CreateHost(out View view, out SceneLayer layer);
+
+        host.Effects.Run(layer, new FadeOutEffect(1f));
+        host.Effects.Advance(0.25f);
+
+        Assert.Equal(1f, view.EffectOpacity);
+        Assert.Equal(0.75f, layer.EffectOpacity, 3);
+    }
+
+    [Fact]
+    public void Run_ReplacesEffectOnSameTargetAndChannel()
+    {
+        using var host = CreateHost(out View view, out _);
+        var first = host.Effects.Run(view, new FadeOutEffect(1f));
+
+        host.Effects.Advance(0.25f);
+        var replacement = host.Effects.Run(view, new FadeInEffect(1f));
+
+        Assert.Equal(EffectStatus.Cancelled, first.Status);
+        Assert.Equal(EffectStatus.Running, replacement.Status);
+        Assert.Single(host.Effects.ActiveEffects);
+        Assert.Equal(0.75f, view.EffectOpacity, 3);
+
+        host.Effects.Advance(0.5f);
+
+        Assert.Equal(0.875f, view.EffectOpacity, 3);
+    }
+
+    [Fact]
+    public void CompatibleChannels_ComposeOnOneTarget()
+    {
+        using var host = CreateHost(out View view, out _);
+
+        host.Effects.Run(view, new FadeOutEffect(1f));
+        host.Effects.Run(
+            view,
+            new SlideOutEffect(
+                EffectDirection.FromLeftToRight,
+                1f,
+                EasingKind.Linear));
+
+        Assert.Equal(2, host.Effects.ActiveEffects.Count);
+
+        host.Effects.Advance(0.5f);
+
+        Assert.Equal(0.5f, view.EffectOpacity, 3);
+        Assert.Equal(0.5f, view.EffectOffsetFactor.X, 3);
+    }
+
+    [Fact]
+    public void Cancel_RestoresStateFromBeforeEffect()
+    {
+        using var host = CreateHost(out View view, out _);
+        var effect = host.Effects.Run(
+            view,
+            new SlideOutEffect(
+                EffectDirection.FromTopToBottom,
+                1f,
+                EasingKind.Linear));
+
+        host.Effects.Advance(0.5f);
+        effect.Cancel();
+
+        Assert.Equal(EffectStatus.Cancelled, effect.Status);
+        Assert.Equal(PointF.Empty, view.EffectOffsetFactor);
+        Assert.Empty(host.Effects.ActiveEffects);
+    }
+
+    [Fact]
+    public void Slide_ChangesPresentationCoordinatesWithoutChangingWorldState()
+    {
+        using var host = CreateHost(out View view, out SceneLayer layer);
+        PointF world = new(20f, 10f);
+
+        host.Effects.Run(
+            view,
+            new SlideOutEffect(
+                EffectDirection.FromLeftToRight,
+                1f,
+                EasingKind.Linear));
+        host.Effects.Advance(0.5f);
+
+        PointF screen = view.WorldPxToScreenPx(layer, world);
+        PointF roundTrip = view.ScreenPxToWorldPx(layer, screen);
+
+        Assert.Equal(120f, screen.X, 3);
+        Assert.Equal(world.X, roundTrip.X, 3);
+        Assert.Equal(world.Y, roundTrip.Y, 3);
+        Assert.Equal(PointF.Empty, view.Camera.PositionPx);
+        Assert.Equal(Point.Empty, layer.OriginPx);
+    }
+
+    [Fact]
+    public void FillAndErase_UpdateRevealState()
+    {
+        using var host = CreateHost(out _, out SceneLayer layer);
+
+        host.Effects.Run(
+            layer,
+            new FillEffect(EffectDirection.FromRightToLeft, 1f));
+        Assert.Equal(0f, layer.EffectReveal);
+
+        host.Effects.Advance(1f);
+        Assert.Equal(1f, layer.EffectReveal);
+
+        host.Effects.Run(
+            layer,
+            new EraseEffect(EffectDirection.FromTopToBottom, 1f));
+        host.Effects.Advance(0.5f);
+
+        Assert.Equal(0.5f, layer.EffectReveal, 3);
+        Assert.Equal(EffectDirection.FromTopToBottom, layer.EffectRevealDirection);
+    }
+
+    [Fact]
+    public void Earthquake_IsViewOnlyAndResetsItsOffsetAtCompletion()
+    {
+        using var host = CreateHost(out View view, out SceneLayer layer);
+        var effect = host.Effects.Run(
+            view,
+            new EarthquakeEffect(1f, intensityPx: 10f, randomSeed: 7));
+
+        host.Effects.Advance(0.25f);
+
+        Assert.NotEqual(PointF.Empty, view.EffectOffsetPx);
+        Assert.Throws<ArgumentException>(() =>
+            host.Effects.Run(layer, new EarthquakeEffect(1f)));
+
+        host.Effects.Advance(0.75f);
+
+        Assert.Equal(EffectStatus.Completed, effect.Status);
+        Assert.Equal(PointF.Empty, view.EffectOffsetPx);
+    }
+
+    [Fact]
+    public void Zoom_DelegatesAnimationToViewportWithoutAdvancingItTwice()
+    {
+        using var host = CreateHost(out View view, out _);
+        var effect = host.Effects.Run(view, new ZoomInEffect(2f, 1f));
+
+        host.Effects.Advance(0.5f);
+
+        Assert.Equal(1f, view.Viewport.Zoom);
+        Assert.True(view.Viewport.IsZoomAnimating);
+
+        view.Update(0.5f);
+
+        Assert.InRange(view.Viewport.Zoom, 1f, 2f);
+        Assert.NotEqual(1f, view.Viewport.Zoom);
+        Assert.Equal(EffectStatus.Running, effect.Status);
+
+        host.Effects.Advance(0.5f);
+
+        Assert.Equal(EffectStatus.Completed, effect.Status);
+        Assert.Equal(2f, view.Viewport.Zoom);
+        Assert.False(view.Viewport.IsZoomAnimating);
+    }
+
+    [Fact]
+    public void Run_RejectsTargetOwnedByAnotherHost()
+    {
+        using var host = CreateHost(out _, out _);
+        using var other = CreateHost(out View otherView, out _);
+
+        Assert.Throws<ArgumentException>(() =>
+            host.Effects.Run(otherView, new FadeOutEffect(1f)));
+    }
+
+    [Theory]
+    [InlineData(EffectDirection.FromLeftToRight, 0f, 0f, 25f, 50f)]
+    [InlineData(EffectDirection.FromRightToLeft, 75f, 0f, 25f, 50f)]
+    [InlineData(EffectDirection.FromTopToBottom, 0f, 0f, 100f, 12.5f)]
+    [InlineData(EffectDirection.FromBottomToTop, 0f, 37.5f, 100f, 12.5f)]
+    public void RevealGeometry_UsesRequestedDirection(
+        EffectDirection direction,
+        float x,
+        float y,
+        float width,
+        float height)
+    {
+        RectangleF actual = EffectGeometry.GetRevealRect(
+            new RectangleF(0f, 0f, 100f, 50f),
+            direction,
+            0.25f);
+
+        Assert.Equal(new RectangleF(x, y, width, height), actual);
+    }
+
+    private static TestRenderSurfaceHost CreateHost(
+        out View view,
+        out SceneLayer layer)
+    {
+        var host = new TestRenderSurfaceHost();
+        layer = host.Scene.AddLayer(10, 10, width: 32, height: 32);
+        host.ViewManager.AddView(new Rectangle(0, 0, 200, 100));
+        view = Assert.Single(host.ViewManager.Views);
+        return host;
+    }
+}

--- a/Testing/Gondwana.Tests/Effects/EffectsRenderingTests.cs
+++ b/Testing/Gondwana.Tests/Effects/EffectsRenderingTests.cs
@@ -11,6 +11,12 @@ namespace Gondwana.Tests.Effects;
 [Collection("Effects rendering")]
 public sealed class EffectsRenderingTests
 {
+    public EffectsRenderingTests()
+    {
+        Engine.Instance.EngineDispatcher.BindToCurrentThread();
+        Engine.Instance.EngineDispatcher.Drain();
+    }
+
     [Fact]
     public void BitmapPath_CompositesViewOpacity()
     {

--- a/Testing/Gondwana.Tests/Effects/EffectsRenderingTests.cs
+++ b/Testing/Gondwana.Tests/Effects/EffectsRenderingTests.cs
@@ -1,0 +1,121 @@
+using System.Drawing;
+using Gondwana.Drawing.Direct;
+using Gondwana.Effects;
+using Gondwana.Rendering;
+using Gondwana.Rendering.Backbuffers;
+using Gondwana.Scenes;
+using SkiaSharp;
+
+namespace Gondwana.Tests.Effects;
+
+[Collection("Effects rendering")]
+public sealed class EffectsRenderingTests
+{
+    [Fact]
+    public void BitmapPath_CompositesViewOpacity()
+    {
+        AssertViewOpacityIsComposited<BitmapBackbuffer>();
+    }
+
+    [Fact]
+    public void GpuFullFramePath_CompositesViewOpacity()
+    {
+        // GpuBackbuffer uses its CPU fallback surface until a GRContext is attached,
+        // while still exercising the GL-thread/full-frame host path.
+        AssertViewOpacityIsComposited<GpuBackbuffer>();
+    }
+
+    [Fact]
+    public void BitmapPath_CompositesSceneLayerOpacity()
+    {
+        AssertSceneLayerOpacityIsComposited<BitmapBackbuffer>();
+    }
+
+    [Fact]
+    public void GpuFullFramePath_CompositesSceneLayerOpacity()
+    {
+        AssertSceneLayerOpacityIsComposited<GpuBackbuffer>();
+    }
+
+    private static void AssertViewOpacityIsComposited<TBackbuffer>()
+        where TBackbuffer : BackbufferBase
+    {
+        using var scene = new Scene();
+        using var host = new RenderSurfaceHost<TBackbuffer>(new TestAdapter(100, 50));
+        host.Bind(scene, limitCameraToWorldBoundPx: false);
+
+        var view = Assert.Single(host.ViewManager.Views);
+        using var rectangle = new DirectRectangle(
+            Color.Red,
+            host,
+            view,
+            new Rectangle(0, 0, 100, 50),
+            nickname: $"effects-render-{typeof(TBackbuffer).Name}")
+            .SetFilled(true);
+
+        host.Effects.Run(view, new FadeOutEffect(1f));
+        host.Effects.Advance(0.5f);
+
+        host.RenderToBackbuffer(tick: 0);
+        host.Backbuffer.EndFrame();
+
+        using SKImage image = host.Backbuffer.Snapshot();
+        using SKBitmap bitmap = SKBitmap.FromImage(image);
+        SKColor pixel = bitmap.GetPixel(50, 25);
+
+        Assert.InRange(pixel.Red, (byte)120, (byte)135);
+        Assert.Equal((byte)0, pixel.Green);
+        Assert.Equal((byte)0, pixel.Blue);
+        Assert.Equal((byte)255, pixel.Alpha);
+
+        host.Backbuffer.BeginFrame();
+    }
+
+    private static void AssertSceneLayerOpacityIsComposited<TBackbuffer>()
+        where TBackbuffer : BackbufferBase
+    {
+        using var scene = new Scene();
+        SceneLayer layer = scene.AddLayer(4, 2, width: 25, height: 25);
+        using var host = new RenderSurfaceHost<TBackbuffer>(new TestAdapter(100, 50));
+        host.Bind(scene, limitCameraToWorldBoundPx: false);
+
+        using var rectangle = new DirectRectangle(
+            Color.Red,
+            host,
+            layer,
+            new Rectangle(0, 0, 100, 50),
+            nickname: $"effects-layer-render-{typeof(TBackbuffer).Name}")
+            .SetFilled(true);
+
+        host.Effects.Run(layer, new FadeOutEffect(1f));
+        host.Effects.Advance(0.5f);
+
+        host.RenderToBackbuffer(tick: 0);
+        host.Backbuffer.EndFrame();
+
+        using SKImage image = host.Backbuffer.Snapshot();
+        using SKBitmap bitmap = SKBitmap.FromImage(image);
+        SKColor pixel = bitmap.GetPixel(50, 25);
+
+        Assert.InRange(pixel.Red, (byte)120, (byte)135);
+        Assert.Equal((byte)0, pixel.Green);
+        Assert.Equal((byte)0, pixel.Blue);
+        Assert.Equal((byte)255, pixel.Alpha);
+
+        host.Backbuffer.BeginFrame();
+    }
+
+    private sealed class TestAdapter(int width, int height)
+        : RenderSurfaceAdapterBase(width, height)
+    {
+        public override void Present(
+            SKImage bufferImage,
+            SKRectI bufferRect,
+            SKRect destRect)
+        {
+        }
+    }
+}
+
+[CollectionDefinition("Effects rendering", DisableParallelization = true)]
+public sealed class EffectsRenderingCollection;


### PR DESCRIPTION
- Add a new effects subsystem for scene transitions and display animations.
- Support fade, slide, wipe, zoom, and earthquake effects with target control.
- Update rendering/view plumbing to run effects during scene and layer drawing.
- Add README docs and tests covering effect management and rendering behavior.