### PR TITLE
feat(widgets): add popup and toast overlays

### DIFF
--- a/Gondwana.Widgets/Overlays/PopupWidget.cs
+++ b/Gondwana.Widgets/Overlays/PopupWidget.cs
@@ -1,0 +1,612 @@
+using System.Drawing;
+using System.Numerics;
+using Gondwana.Drawing;
+using Gondwana.Drawing.Direct;
+using Gondwana.Rendering;
+using Gondwana.Rendering.Views;
+using Gondwana.Scenes;
+using Gondwana.Timers;
+using SkiaSharp;
+
+namespace Gondwana.Widgets.Overlays;
+
+/// <summary>
+/// Displays short-lived text or image content in view or scene-layer coordinates.
+/// </summary>
+/// <remarks>
+/// A scene-layer popup can take its source from a <see cref="Tile"/> or fixed
+/// grid cell. The source is resolved when <see cref="ShowPopup"/> is called and
+/// the popup then moves independently, which is appropriate for floating damage,
+/// score, and status-effect feedback.
+/// </remarks>
+public sealed class PopupWidget : WidgetBase
+{
+    private bool _disposed;
+    private bool _isActive;
+    private float _elapsedSec;
+    private float _lifetimeSec = 1f;
+    private float _fadeInSec = 0.08f;
+    private float _fadeOutSec = 0.25f;
+    private long _lastAnimationTick;
+    private Func<Vector2> _sourceResolver;
+
+    /// <summary>
+    /// Occurs after the popup reaches the end of its configured lifetime.
+    /// </summary>
+    public event Action? Completed;
+
+    /// <summary>
+    /// Initializes a text popup in absolute view/screen coordinates.
+    /// </summary>
+    public PopupWidget(
+        RenderSurfaceHostBase renderSurfaceHost,
+        View view,
+        Rectangle screenBounds,
+        string text,
+        string? nickname = null)
+        : base(
+            renderSurfaceHost,
+            DirectDrawingMode.View,
+            screenBounds.Location,
+            nickname)
+    {
+        ValidateBounds(screenBounds);
+
+        Text = CreateText(
+            renderSurfaceHost,
+            view,
+            screenBounds,
+            text,
+            $"{Nickname}.text");
+
+        Content = Text;
+        _sourceResolver = () => new Vector2(screenBounds.X, screenBounds.Y);
+
+        CompleteInitialization(Content);
+    }
+
+    /// <summary>
+    /// Initializes a text popup in scene-layer world coordinates.
+    /// </summary>
+    public PopupWidget(
+        RenderSurfaceHostBase renderSurfaceHost,
+        SceneLayer sceneLayer,
+        Rectangle worldBounds,
+        string text,
+        string? nickname = null)
+        : base(
+            renderSurfaceHost,
+            DirectDrawingMode.SceneLayer,
+            worldBounds.Location,
+            nickname)
+    {
+        ValidateBounds(worldBounds);
+
+        Text = CreateText(
+            renderSurfaceHost,
+            sceneLayer,
+            worldBounds,
+            text,
+            $"{Nickname}.text");
+
+        Content = Text;
+        _sourceResolver = () => new Vector2(worldBounds.X, worldBounds.Y);
+
+        CompleteInitialization(Content);
+    }
+
+    /// <summary>
+    /// Initializes a text popup whose source is resolved from a tile when shown.
+    /// </summary>
+    public PopupWidget(
+        RenderSurfaceHostBase renderSurfaceHost,
+        Tile source,
+        Size size,
+        string text,
+        WidgetAnchor sourceAnchor = WidgetAnchor.Center,
+        Point? offsetPx = null,
+        string? nickname = null)
+        : this(
+            renderSurfaceHost,
+            source?.SceneLayer ?? throw new ArgumentNullException(nameof(source)),
+            new Rectangle(Point.Empty, size),
+            text,
+            nickname)
+    {
+        BindTo(source, sourceAnchor, offsetPx);
+    }
+
+    /// <summary>
+    /// Initializes an image popup in absolute view/screen coordinates.
+    /// </summary>
+    public PopupWidget(
+        RenderSurfaceHostBase renderSurfaceHost,
+        View view,
+        Rectangle screenBounds,
+        SKImage image,
+        string? nickname = null)
+        : base(
+            renderSurfaceHost,
+            DirectDrawingMode.View,
+            screenBounds.Location,
+            nickname)
+    {
+        ArgumentNullException.ThrowIfNull(image);
+        ValidateBounds(screenBounds);
+
+        Image = new DirectImage(
+            image,
+            renderSurfaceHost,
+            view,
+            screenBounds,
+            $"{Nickname}.image");
+
+        Content = Image;
+        _sourceResolver = () => new Vector2(screenBounds.X, screenBounds.Y);
+
+        CompleteInitialization(Content);
+    }
+
+    /// <summary>
+    /// Initializes an image popup in scene-layer world coordinates.
+    /// </summary>
+    public PopupWidget(
+        RenderSurfaceHostBase renderSurfaceHost,
+        SceneLayer sceneLayer,
+        Rectangle worldBounds,
+        SKImage image,
+        string? nickname = null)
+        : base(
+            renderSurfaceHost,
+            DirectDrawingMode.SceneLayer,
+            worldBounds.Location,
+            nickname)
+    {
+        ArgumentNullException.ThrowIfNull(image);
+        ValidateBounds(worldBounds);
+
+        Image = new DirectImage(
+            image,
+            renderSurfaceHost,
+            sceneLayer,
+            worldBounds,
+            $"{Nickname}.image");
+
+        Content = Image;
+        _sourceResolver = () => new Vector2(worldBounds.X, worldBounds.Y);
+
+        CompleteInitialization(Content);
+    }
+
+    /// <summary>
+    /// Initializes a bitmap popup in absolute view/screen coordinates.
+    /// </summary>
+    public PopupWidget(
+        RenderSurfaceHostBase renderSurfaceHost,
+        View view,
+        Rectangle screenBounds,
+        SKBitmap bitmap,
+        string? nickname = null)
+        : base(
+            renderSurfaceHost,
+            DirectDrawingMode.View,
+            screenBounds.Location,
+            nickname)
+    {
+        ArgumentNullException.ThrowIfNull(bitmap);
+        ValidateBounds(screenBounds);
+
+        Image = new DirectImage(
+            bitmap,
+            renderSurfaceHost,
+            view,
+            screenBounds,
+            $"{Nickname}.image");
+
+        Content = Image;
+        _sourceResolver = () => new Vector2(screenBounds.X, screenBounds.Y);
+
+        CompleteInitialization(Content);
+    }
+
+    /// <summary>
+    /// Initializes a bitmap popup in scene-layer world coordinates.
+    /// </summary>
+    public PopupWidget(
+        RenderSurfaceHostBase renderSurfaceHost,
+        SceneLayer sceneLayer,
+        Rectangle worldBounds,
+        SKBitmap bitmap,
+        string? nickname = null)
+        : base(
+            renderSurfaceHost,
+            DirectDrawingMode.SceneLayer,
+            worldBounds.Location,
+            nickname)
+    {
+        ArgumentNullException.ThrowIfNull(bitmap);
+        ValidateBounds(worldBounds);
+
+        Image = new DirectImage(
+            bitmap,
+            renderSurfaceHost,
+            sceneLayer,
+            worldBounds,
+            $"{Nickname}.image");
+
+        Content = Image;
+        _sourceResolver = () => new Vector2(worldBounds.X, worldBounds.Y);
+
+        CompleteInitialization(Content);
+    }
+
+    /// <summary>
+    /// Gets the direct drawing displayed by this popup.
+    /// </summary>
+    public IDirectCompositeChild Content { get; }
+
+    /// <summary>
+    /// Gets the popup's text drawing, or null for an image popup.
+    /// </summary>
+    public TextBlock? Text { get; }
+
+    /// <summary>
+    /// Gets the popup's image drawing, or null for a text popup.
+    /// </summary>
+    public DirectImage? Image { get; }
+
+    /// <summary>
+    /// Gets the tile used to resolve the popup source, when one is configured.
+    /// </summary>
+    public Tile? SourceTile { get; private set; }
+
+    /// <summary>
+    /// Gets the fixed grid coordinate used to resolve the popup source, when one is configured.
+    /// </summary>
+    public Point? SourceGridLocation { get; private set; }
+
+    /// <summary>
+    /// Gets or sets the popup lifetime in seconds.
+    /// </summary>
+    public float LifetimeSec
+    {
+        get => _lifetimeSec;
+        set => _lifetimeSec = value > 0f
+            ? value
+            : throw new ArgumentOutOfRangeException(nameof(value));
+    }
+
+    /// <summary>
+    /// Gets or sets the fade-in duration in seconds.
+    /// </summary>
+    public float FadeInSec
+    {
+        get => _fadeInSec;
+        set => _fadeInSec = value >= 0f
+            ? value
+            : throw new ArgumentOutOfRangeException(nameof(value));
+    }
+
+    /// <summary>
+    /// Gets or sets the fade-out duration in seconds.
+    /// </summary>
+    public float FadeOutSec
+    {
+        get => _fadeOutSec;
+        set => _fadeOutSec = value >= 0f
+            ? value
+            : throw new ArgumentOutOfRangeException(nameof(value));
+    }
+
+    /// <summary>
+    /// Gets or sets the initial popup velocity in pixels per second.
+    /// Scene-layer popups use world pixels; view popups use screen pixels.
+    /// </summary>
+    public Vector2 VelocityPxPerSec { get; set; } = new(0f, -48f);
+
+    /// <summary>
+    /// Gets or sets popup acceleration in pixels per second squared.
+    /// </summary>
+    public Vector2 AccelerationPxPerSecSquared { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the popup disposes itself after completion.
+    /// </summary>
+    public bool DisposeOnComplete { get; set; } = true;
+
+    /// <summary>
+    /// Shows the popup, resolves its current source, and starts its movement and fades.
+    /// </summary>
+    public PopupWidget ShowPopup()
+    {
+        Show();
+        return this;
+    }
+
+    /// <summary>
+    /// Uses a fixed top-left location as the popup source.
+    /// </summary>
+    public PopupWidget SetSourceLocation(Point locationPx)
+    {
+        SourceTile = null;
+        SourceGridLocation = null;
+        _sourceResolver = () => new Vector2(locationPx.X, locationPx.Y);
+        SetPosition(locationPx.X, locationPx.Y);
+        return this;
+    }
+
+    /// <summary>
+    /// Resolves the popup source from an anchor point on a tile when the popup is shown.
+    /// </summary>
+    public PopupWidget BindTo(
+        Tile source,
+        WidgetAnchor sourceAnchor = WidgetAnchor.Center,
+        Point? offsetPx = null)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        if (Mode != DirectDrawingMode.SceneLayer)
+            throw new InvalidOperationException("Only a scene-layer popup can bind to a tile.");
+
+        if (!ReferenceEquals(SceneLayer, source.SceneLayer))
+            throw new ArgumentException("The source tile must belong to the popup's SceneLayer.", nameof(source));
+
+        Point offset = offsetPx ?? Point.Empty;
+
+        SourceTile = source;
+        SourceGridLocation = source is SceneLayerTile fixedTile
+            ? fixedTile.GridCoordinatesAbs
+            : null;
+
+        _sourceResolver = () => GetCenteredSourcePosition(
+            source.DrawLocationWorld,
+            GetContentSize(),
+            sourceAnchor,
+            offset);
+
+        SetPosition(_sourceResolver());
+        return this;
+    }
+
+    /// <summary>
+    /// Resolves the popup source from a fixed grid cell when the popup is shown.
+    /// </summary>
+    public PopupWidget BindTo(
+        SceneLayer sceneLayer,
+        Point gridLocation,
+        WidgetAnchor sourceAnchor = WidgetAnchor.Center,
+        Point? offsetPx = null)
+    {
+        ArgumentNullException.ThrowIfNull(sceneLayer);
+
+        SceneLayerTile tile = sceneLayer[gridLocation]
+            ?? throw new ArgumentOutOfRangeException(nameof(gridLocation), "The grid location is outside the SceneLayer.");
+
+        BindTo(tile, sourceAnchor, offsetPx);
+        SourceGridLocation = gridLocation;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the popup text. Throws when this is an image popup.
+    /// </summary>
+    public PopupWidget SetText(string text)
+    {
+        if (Text is null)
+            throw new InvalidOperationException("This popup contains an image, not text.");
+
+        Text.SetText(text);
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the popup font. Throws when this is an image popup.
+    /// </summary>
+    public PopupWidget SetFont(
+        SKTypeface typeface,
+        float size,
+        float? minSize = null)
+    {
+        if (Text is null)
+            throw new InvalidOperationException("This popup contains an image, not text.");
+
+        Text.SetFont(typeface, size, minSize);
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the popup text color. Throws when this is an image popup.
+    /// </summary>
+    public PopupWidget SetTextColor(SKColor color)
+    {
+        if (Text is null)
+            throw new InvalidOperationException("This popup contains an image, not text.");
+
+        Text.SetColors(color, SKColors.Transparent);
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the popup Z-order.
+    /// </summary>
+    public PopupWidget SetPopupZOrder(int zOrder)
+    {
+        Content.SetZOrder(zOrder);
+        return this;
+    }
+
+    /// <summary>
+    /// Completes and hides the popup immediately.
+    /// </summary>
+    public void Dismiss()
+    {
+        if (!_isActive || _disposed)
+            return;
+
+        CompletePopup();
+    }
+
+    /// <inheritdoc/>
+    public override void Update(long tick)
+    {
+        if (_disposed || tick <= _lastAnimationTick)
+            return;
+
+        float elapsedSec = HighResTimer.GetDuration(_lastAnimationTick, tick);
+        _lastAnimationTick = tick;
+
+        base.Update(tick);
+
+        if (!_isActive)
+            return;
+
+        _elapsedSec += elapsedSec;
+
+        if (_elapsedSec >= LifetimeSec)
+        {
+            CompletePopup();
+            return;
+        }
+
+        float opacity = 1f;
+
+        if (FadeInSec > 0f && _elapsedSec < FadeInSec)
+            opacity = Math.Clamp(_elapsedSec / FadeInSec, 0f, 1f);
+
+        float remainingSec = LifetimeSec - _elapsedSec;
+
+        if (FadeOutSec > 0f && remainingSec < FadeOutSec)
+            opacity = Math.Min(opacity, Math.Clamp(remainingSec / FadeOutSec, 0f, 1f));
+
+        SetOpacity(opacity);
+    }
+
+    /// <inheritdoc/>
+    public override void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        Completed = null;
+        base.Dispose();
+    }
+
+    /// <inheritdoc/>
+    protected override void ProcessShown()
+    {
+        base.ProcessShown();
+
+        _elapsedSec = 0f;
+        _lastAnimationTick = HighResTimer.GetCurrentTick();
+        _isActive = true;
+
+        Movement.StopAllMovement();
+        SetPosition(_sourceResolver());
+        SetOpacity(FadeInSec > 0f ? 0f : 1f);
+        Movement.SetVelocity(VelocityPxPerSec);
+        Movement.SetAcceleration(AccelerationPxPerSecSquared);
+    }
+
+    /// <inheritdoc/>
+    protected override void ProcessHidden()
+    {
+        _isActive = false;
+        Movement.StopAllMovement();
+        base.ProcessHidden();
+    }
+
+    private void CompleteInitialization(IDirectCompositeChild content)
+    {
+        IsInputEnabled = false;
+        IsPointerInputEnabled = false;
+
+        Add(
+            content,
+            keepCurrentOffset: false,
+            explicitLocalOffsetPx: Vector2.Zero);
+
+        SetPopupZOrder(int.MaxValue - 50);
+        SetIsVisible(false);
+    }
+
+    private void CompletePopup()
+    {
+        Hide();
+        Completed?.Invoke();
+
+        if (DisposeOnComplete)
+            Dispose();
+    }
+
+    private Size GetContentSize()
+    {
+        Rectangle bounds = Mode == DirectDrawingMode.View
+            ? Content.ScreenBounds
+            : Content.WorldBounds;
+
+        return bounds.Size;
+    }
+
+    private static Vector2 GetCenteredSourcePosition(
+        Rectangle sourceBounds,
+        Size contentSize,
+        WidgetAnchor sourceAnchor,
+        Point offsetPx)
+    {
+        PointF anchor = sourceAnchor.GetPoint(sourceBounds);
+
+        return new Vector2(
+            anchor.X - contentSize.Width / 2f + offsetPx.X,
+            anchor.Y - contentSize.Height / 2f + offsetPx.Y);
+    }
+
+    private static TextBlock CreateText(
+        RenderSurfaceHostBase host,
+        View view,
+        Rectangle bounds,
+        string text,
+        string nickname)
+    {
+        return new TextBlock(
+                host,
+                view,
+                bounds,
+                nickname)
+            .SetText(text)
+            .SetFont(SKTypeface.Default, 22f, minSize: 10f)
+            .SetColors(SKColors.White, SKColors.Transparent)
+            .SetAlignment(SKTextAlign.Center, TextBlock.VerticalAlign.Center)
+            .EnableWrapping(false)
+            .UseShadow(true)
+            .UseOutline(true);
+    }
+
+    private static TextBlock CreateText(
+        RenderSurfaceHostBase host,
+        SceneLayer sceneLayer,
+        Rectangle bounds,
+        string text,
+        string nickname)
+    {
+        return new TextBlock(
+                host,
+                sceneLayer,
+                view: null,
+                worldBounds: bounds,
+                nickname: nickname)
+            .SetText(text)
+            .SetFont(SKTypeface.Default, 22f, minSize: 10f)
+            .SetColors(SKColors.White, SKColors.Transparent)
+            .SetAlignment(SKTextAlign.Center, TextBlock.VerticalAlign.Center)
+            .EnableWrapping(false)
+            .UseShadow(true)
+            .UseOutline(true);
+    }
+
+    private static void ValidateBounds(Rectangle bounds)
+    {
+        if (bounds.Width <= 0 || bounds.Height <= 0)
+            throw new ArgumentOutOfRangeException(nameof(bounds), "Popup bounds must have a positive width and height.");
+    }
+}

--- a/Gondwana.Widgets/Overlays/ToastWidget.cs
+++ b/Gondwana.Widgets/Overlays/ToastWidget.cs
@@ -1,0 +1,554 @@
+using System.Drawing;
+using System.Numerics;
+using Gondwana.Drawing.Direct;
+using Gondwana.Physics.Movement.Easing;
+using Gondwana.Rendering;
+using Gondwana.Rendering.Views;
+using Gondwana.Timers;
+using SkiaSharp;
+
+namespace Gondwana.Widgets.Overlays;
+
+/// <summary>
+/// Defines how a toast enters its view.
+/// </summary>
+public enum ToastTransition
+{
+    /// <summary>The toast moves from outside the view to its target bounds.</summary>
+    Slide,
+
+    /// <summary>The toast remains at its target bounds and fades from transparent.</summary>
+    Fade
+}
+
+/// <summary>
+/// Defines the view edge from which a sliding toast enters.
+/// </summary>
+public enum ToastSlideOrigin
+{
+    /// <summary>The toast enters from above the view.</summary>
+    Top,
+
+    /// <summary>The toast enters from the right of the view.</summary>
+    Right,
+
+    /// <summary>The toast enters from below the view.</summary>
+    Bottom,
+
+    /// <summary>The toast enters from the left of the view.</summary>
+    Left
+}
+
+/// <summary>
+/// Represents the lifecycle state of a <see cref="ToastWidget"/>.
+/// </summary>
+public enum ToastState
+{
+    /// <summary>The toast is not being shown.</summary>
+    Hidden,
+
+    /// <summary>The toast is moving or fading into view.</summary>
+    Entering,
+
+    /// <summary>The toast is resting at its target bounds.</summary>
+    Holding,
+
+    /// <summary>The toast is moving or fading out of view.</summary>
+    Exiting
+}
+
+/// <summary>
+/// Displays a text notification inside one <see cref="View"/> with a slide or
+/// fade transition and optional automatic dismissal.
+/// </summary>
+/// <remarks>
+/// Screen bounds use absolute render-surface pixels, matching other view-mode
+/// direct drawings. Set <see cref="HoldDurationSec"/> to <see langword="null"/>
+/// for a toast that remains until <see cref="Dismiss"/> is called or the toast
+/// is clicked while <see cref="DismissOnClick"/> is enabled.
+/// </remarks>
+public sealed class ToastWidget : WidgetBase
+{
+    private bool _disposed;
+    private float _transitionDurationSec = 0.3f;
+    private float? _holdDurationSec = 3f;
+    private float _phaseElapsedSec;
+    private long _lastAnimationTick;
+    private Vector2 _phaseStartPosition;
+    private Vector2 _phaseEndPosition;
+    private float _phaseStartOpacity;
+    private float _phaseEndOpacity;
+
+    /// <summary>
+    /// Occurs after the toast completes dismissal and is hidden.
+    /// </summary>
+    public event Action? Dismissed;
+
+    /// <summary>
+    /// Initializes a toast with explicit target bounds in absolute screen pixels.
+    /// </summary>
+    public ToastWidget(
+        RenderSurfaceHostBase renderSurfaceHost,
+        View view,
+        Rectangle targetBounds,
+        string text,
+        string? nickname = null)
+        : base(
+            renderSurfaceHost,
+            DirectDrawingMode.View,
+            targetBounds.Location,
+            nickname)
+    {
+        ValidateBounds(targetBounds);
+
+        TargetBounds = targetBounds;
+
+        Background = new DirectRectangle(
+                Color.FromArgb(232, 35, 38, 45),
+                renderSurfaceHost,
+                view,
+                targetBounds,
+                $"{Nickname}.background")
+            .SetFilled(true)
+            .SetBorderColor(Color.FromArgb(245, 215, 219, 225))
+            .SetStrokeWidth(1f)
+            .SetStrokeAlign(DirectRectangle.StrokeAlign.Inside)
+            .SetCornerRadius(6f);
+
+        Label = new TextBlock(
+                renderSurfaceHost,
+                view,
+                targetBounds,
+                $"{Nickname}.label")
+            .SetText(text)
+            .SetFont(SKTypeface.Default, 17f, minSize: 11f)
+            .SetColors(SKColors.White, SKColors.Transparent)
+            .SetAlignment(SKTextAlign.Center, TextBlock.VerticalAlign.Center)
+            .EnableWrapping(true);
+
+        Label.HorizontalPadding = 12f;
+        Label.VerticalPadding = 8f;
+
+        Add(
+            Background,
+            keepCurrentOffset: false,
+            explicitLocalOffsetPx: Vector2.Zero);
+
+        Add(
+            Label,
+            keepCurrentOffset: false,
+            explicitLocalOffsetPx: Vector2.Zero);
+
+        SetToastZOrder(int.MaxValue - 100);
+        SetIsVisible(false);
+    }
+
+    /// <summary>
+    /// Initializes a toast positioned from a standard anchor inside the view.
+    /// </summary>
+    public ToastWidget(
+        RenderSurfaceHostBase renderSurfaceHost,
+        View view,
+        Size size,
+        string text,
+        WidgetAnchor targetAnchor = WidgetAnchor.TopRight,
+        int marginPx = 16,
+        string? nickname = null)
+        : this(
+            renderSurfaceHost,
+            view,
+            GetAnchoredBounds(view, size, targetAnchor, marginPx),
+            text,
+            nickname)
+    {
+    }
+
+    /// <summary>
+    /// Gets the rectangle used for the toast background and border.
+    /// </summary>
+    public DirectRectangle Background { get; }
+
+    /// <summary>
+    /// Gets the text drawing used for the toast message.
+    /// </summary>
+    public TextBlock Label { get; }
+
+    /// <summary>
+    /// Gets the current toast lifecycle state.
+    /// </summary>
+    public ToastState CurrentState { get; private set; } = ToastState.Hidden;
+
+    /// <summary>
+    /// Gets or sets the entrance and animated-dismissal transition.
+    /// </summary>
+    public ToastTransition Transition { get; set; } = ToastTransition.Slide;
+
+    /// <summary>
+    /// Gets or sets the edge used by slide transitions.
+    /// </summary>
+    public ToastSlideOrigin SlideOrigin { get; set; } = ToastSlideOrigin.Right;
+
+    /// <summary>
+    /// Gets or sets an optional explicit slide source top-left in absolute screen pixels.
+    /// When null, the source is calculated just outside <see cref="View.Viewport"/>.
+    /// </summary>
+    public Point? SourceLocationPx { get; set; }
+
+    /// <summary>
+    /// Gets or sets the gap between a calculated slide source and the view edge.
+    /// </summary>
+    public int SourceOffsetPx { get; set; } = 8;
+
+    /// <summary>
+    /// Gets or sets the transition duration in seconds. Zero performs the transition immediately.
+    /// </summary>
+    public float TransitionDurationSec
+    {
+        get => _transitionDurationSec;
+        set => _transitionDurationSec = value >= 0f
+            ? value
+            : throw new ArgumentOutOfRangeException(nameof(value));
+    }
+
+    /// <summary>
+    /// Gets or sets how long the toast remains at its target before automatic dismissal.
+    /// Null disables automatic dismissal.
+    /// </summary>
+    public float? HoldDurationSec
+    {
+        get => _holdDurationSec;
+        set => _holdDurationSec = value is null or >= 0f
+            ? value
+            : throw new ArgumentOutOfRangeException(nameof(value));
+    }
+
+    /// <summary>
+    /// Gets or sets the easing used by the entrance transition.
+    /// </summary>
+    public EasingKind EntranceEasing { get; set; } = EasingKind.EaseOutCubic;
+
+    /// <summary>
+    /// Gets or sets the easing used by the dismissal transition.
+    /// </summary>
+    public EasingKind ExitEasing { get; set; } = EasingKind.EaseInCubic;
+
+    /// <summary>
+    /// Gets or sets whether dismissal reverses the configured entrance transition.
+    /// </summary>
+    public bool AnimateDismissal { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets whether a primary-pointer click dismisses the toast.
+    /// </summary>
+    public bool DismissOnClick { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets whether the toast disposes itself after dismissal.
+    /// </summary>
+    public bool DisposeOnDismiss { get; set; } = true;
+
+    /// <summary>
+    /// Gets the target bounds at which the toast rests, in absolute screen pixels.
+    /// </summary>
+    public Rectangle TargetBounds { get; private set; }
+
+    /// <summary>
+    /// Shows the toast and begins its entrance transition.
+    /// </summary>
+    public ToastWidget ShowToast()
+    {
+        Show();
+        return this;
+    }
+
+    /// <summary>
+    /// Begins dismissal. Repeated calls while exiting or hidden have no effect.
+    /// </summary>
+    public void Dismiss()
+    {
+        if (_disposed || CurrentState is ToastState.Hidden or ToastState.Exiting)
+            return;
+
+        if (!AnimateDismissal || TransitionDurationSec <= 0f)
+        {
+            CompleteDismissal();
+            return;
+        }
+
+        CurrentState = ToastState.Exiting;
+        BeginPhase(
+            GetPosition(),
+            Transition == ToastTransition.Slide
+                ? GetSourcePosition()
+                : GetPosition(),
+            GetCurrentOpacity(),
+            Transition == ToastTransition.Fade ? 0f : 1f);
+    }
+
+    /// <summary>
+    /// Changes the target bounds used the next time the toast is shown.
+    /// </summary>
+    public ToastWidget SetTargetBounds(Rectangle targetBounds)
+    {
+        ValidateBounds(targetBounds);
+
+        TargetBounds = targetBounds;
+        Background.ScreenBounds = targetBounds;
+        Label.ScreenBounds = targetBounds;
+        SetPosition(targetBounds.X, targetBounds.Y);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the toast message.
+    /// </summary>
+    public ToastWidget SetText(string text)
+    {
+        Label.SetText(text);
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the background Z-order and places the label immediately above it.
+    /// </summary>
+    public ToastWidget SetToastZOrder(int zOrder)
+    {
+        Background.ZOrder = zOrder;
+        Label.ZOrder = zOrder + 1;
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public override void Update(long tick)
+    {
+        if (_disposed || tick <= _lastAnimationTick)
+            return;
+
+        float elapsedSec = HighResTimer.GetDuration(_lastAnimationTick, tick);
+        _lastAnimationTick = tick;
+
+        base.Update(tick);
+
+        switch (CurrentState)
+        {
+            case ToastState.Entering:
+                AdvanceTransition(elapsedSec, entering: true);
+                break;
+
+            case ToastState.Holding:
+                _phaseElapsedSec += elapsedSec;
+
+                if (HoldDurationSec is { } holdSec &&
+                    _phaseElapsedSec >= holdSec)
+                {
+                    Dismiss();
+                }
+                break;
+
+            case ToastState.Exiting:
+                AdvanceTransition(elapsedSec, entering: false);
+                break;
+        }
+    }
+
+    /// <inheritdoc/>
+    public override void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        Dismissed = null;
+        base.Dispose();
+    }
+
+    /// <inheritdoc/>
+    protected override void ProcessShown()
+    {
+        base.ProcessShown();
+
+        CurrentState = ToastState.Entering;
+        _lastAnimationTick = HighResTimer.GetCurrentTick();
+
+        Vector2 target = new(TargetBounds.X, TargetBounds.Y);
+        Vector2 source = Transition == ToastTransition.Slide
+            ? GetSourcePosition()
+            : target;
+
+        BeginPhase(
+            source,
+            target,
+            Transition == ToastTransition.Fade ? 0f : 1f,
+            1f);
+
+        if (TransitionDurationSec <= 0f)
+            CompleteEntrance();
+    }
+
+    /// <inheritdoc/>
+    protected override void ProcessHidden()
+    {
+        CurrentState = ToastState.Hidden;
+        Movement.StopAllMovement();
+        base.ProcessHidden();
+    }
+
+    /// <inheritdoc/>
+    protected override void OnPointerClick(WidgetPointerEventArgs args)
+    {
+        base.OnPointerClick(args);
+
+        if (!DismissOnClick || !args.IsPrimaryButton)
+            return;
+
+        args.Handled = true;
+        Dismiss();
+    }
+
+    private void BeginPhase(
+        Vector2 startPosition,
+        Vector2 endPosition,
+        float startOpacity,
+        float endOpacity)
+    {
+        _phaseElapsedSec = 0f;
+        _phaseStartPosition = startPosition;
+        _phaseEndPosition = endPosition;
+        _phaseStartOpacity = startOpacity;
+        _phaseEndOpacity = endOpacity;
+
+        SetPosition(startPosition);
+        SetOpacity(startOpacity);
+    }
+
+    private void AdvanceTransition(float elapsedSec, bool entering)
+    {
+        _phaseElapsedSec += elapsedSec;
+
+        float progress = TransitionDurationSec <= 0f
+            ? 1f
+            : Math.Clamp(_phaseElapsedSec / TransitionDurationSec, 0f, 1f);
+
+        Func<float, float> easing = EasingFunctions.From(
+            entering ? EntranceEasing : ExitEasing);
+
+        float eased = Math.Clamp(easing(progress), 0f, 1f);
+
+        SetPosition(Vector2.Lerp(
+            _phaseStartPosition,
+            _phaseEndPosition,
+            eased));
+
+        SetOpacity(
+            _phaseStartOpacity
+            + (_phaseEndOpacity - _phaseStartOpacity) * eased);
+
+        if (progress < 1f)
+            return;
+
+        if (entering)
+            CompleteEntrance();
+        else
+            CompleteDismissal();
+    }
+
+    private void CompleteEntrance()
+    {
+        SetPosition(TargetBounds.X, TargetBounds.Y);
+        SetOpacity(1f);
+        CurrentState = ToastState.Holding;
+        _phaseElapsedSec = 0f;
+
+        if (HoldDurationSec == 0f)
+            Dismiss();
+    }
+
+    private void CompleteDismissal()
+    {
+        Hide();
+        Dismissed?.Invoke();
+
+        if (DisposeOnDismiss)
+            Dispose();
+    }
+
+    private Vector2 GetSourcePosition()
+    {
+        if (SourceLocationPx is { } explicitSource)
+            return new Vector2(explicitSource.X, explicitSource.Y);
+
+        Rectangle viewport = View!.Viewport.TargetRectPx;
+
+        return SlideOrigin switch
+        {
+            ToastSlideOrigin.Top => new Vector2(
+                TargetBounds.X,
+                viewport.Top - TargetBounds.Height - SourceOffsetPx),
+
+            ToastSlideOrigin.Right => new Vector2(
+                viewport.Right + SourceOffsetPx,
+                TargetBounds.Y),
+
+            ToastSlideOrigin.Bottom => new Vector2(
+                TargetBounds.X,
+                viewport.Bottom + SourceOffsetPx),
+
+            ToastSlideOrigin.Left => new Vector2(
+                viewport.Left - TargetBounds.Width - SourceOffsetPx,
+                TargetBounds.Y),
+
+            _ => throw new ArgumentOutOfRangeException()
+        };
+    }
+
+    private float GetCurrentOpacity()
+    {
+        return Children.Count == 0
+            ? 1f
+            : Children[0] is DirectDrawingBase drawing
+                ? drawing.Opacity
+                : 1f;
+    }
+
+    private static Rectangle GetAnchoredBounds(
+        View view,
+        Size size,
+        WidgetAnchor anchor,
+        int marginPx)
+    {
+        ArgumentNullException.ThrowIfNull(view);
+
+        if (size.Width <= 0 || size.Height <= 0)
+            throw new ArgumentOutOfRangeException(nameof(size));
+
+        if (marginPx < 0)
+            throw new ArgumentOutOfRangeException(nameof(marginPx));
+
+        Rectangle viewport = view.Viewport.TargetRectPx;
+
+        int x = anchor switch
+        {
+            WidgetAnchor.TopLeft or WidgetAnchor.CenterLeft or WidgetAnchor.BottomLeft => viewport.Left + marginPx,
+            WidgetAnchor.TopCenter or WidgetAnchor.Center or WidgetAnchor.BottomCenter => viewport.Left + (viewport.Width - size.Width) / 2,
+            WidgetAnchor.TopRight or WidgetAnchor.CenterRight or WidgetAnchor.BottomRight => viewport.Right - size.Width - marginPx,
+            _ => throw new ArgumentOutOfRangeException(nameof(anchor), anchor, null)
+        };
+
+        int y = anchor switch
+        {
+            WidgetAnchor.TopLeft or WidgetAnchor.TopCenter or WidgetAnchor.TopRight => viewport.Top + marginPx,
+            WidgetAnchor.CenterLeft or WidgetAnchor.Center or WidgetAnchor.CenterRight => viewport.Top + (viewport.Height - size.Height) / 2,
+            WidgetAnchor.BottomLeft or WidgetAnchor.BottomCenter or WidgetAnchor.BottomRight => viewport.Bottom - size.Height - marginPx,
+            _ => throw new ArgumentOutOfRangeException(nameof(anchor), anchor, null)
+        };
+
+        return new Rectangle(x, y, size.Width, size.Height);
+    }
+
+    private static void ValidateBounds(Rectangle bounds)
+    {
+        if (bounds.Width <= 0 || bounds.Height <= 0)
+            throw new ArgumentOutOfRangeException(nameof(bounds), "Toast bounds must have a positive width and height.");
+    }
+}

--- a/Gondwana.Widgets/README.md
+++ b/Gondwana.Widgets/README.md
@@ -46,6 +46,59 @@ A typical widget can be used for in-game interface elements such as:
 
 Exact usage depends on the specific widget type being used.
 
+### Toast notifications
+
+```csharp
+var toast = new ToastWidget(
+    RenderSurface.Host,
+    view,
+    new Size(320, 72),
+    "Game saved",
+    WidgetAnchor.TopRight)
+{
+    Transition = ToastTransition.Slide,
+    SlideOrigin = ToastSlideOrigin.Right,
+    HoldDurationSec = 2.5f
+};
+
+toast.ShowToast();
+```
+
+Set `HoldDurationSec` to `null` for a toast that remains until `Dismiss()` is
+called. An explicit `Rectangle` constructor and `SourceLocationPx` allow exact
+screen-coordinate placement when the standard anchors are not appropriate.
+
+### Floating text and images
+
+```csharp
+var damage = new PopupWidget(
+        RenderSurface.Host,
+        targetSprite,
+        new Size(96, 36),
+        "-25",
+        WidgetAnchor.TopCenter)
+    .SetTextColor(SKColors.OrangeRed);
+
+damage.VelocityPxPerSec = new Vector2(0f, -64f);
+damage.ShowPopup();
+```
+
+`PopupWidget` also accepts view or scene-layer bounds and `SKImage`/`SKBitmap`
+content. Use `BindTo(sceneLayer, gridLocation)` to originate an effect from a
+fixed grid cell.
+
+### Image-filled rectangles
+
+```csharp
+panel.SetFillImage(
+    smallTileBitmap,
+    DirectRectangle.ImageFillMode.Repeat,
+    filterQuality: SKFilterQuality.None);
+```
+
+Image fills support `Stretch`, `Fit`, `Fill`, `Center`, `PixelPerfect`, and
+`Repeat`. The image is clipped to the rectangle, including rounded corners.
+
 ## Widget Scope
 
 `Gondwana.Widgets` is intended for **game UI**, not operating-system UI.

--- a/Gondwana.Widgets/WidgetAnchor.cs
+++ b/Gondwana.Widgets/WidgetAnchor.cs
@@ -1,0 +1,61 @@
+using System.Drawing;
+
+namespace Gondwana.Widgets;
+
+/// <summary>
+/// Identifies one of the nine common anchor points on a rectangle.
+/// </summary>
+public enum WidgetAnchor
+{
+    /// <summary>The upper-left corner.</summary>
+    TopLeft,
+
+    /// <summary>The center of the upper edge.</summary>
+    TopCenter,
+
+    /// <summary>The upper-right corner.</summary>
+    TopRight,
+
+    /// <summary>The center of the left edge.</summary>
+    CenterLeft,
+
+    /// <summary>The center of the rectangle.</summary>
+    Center,
+
+    /// <summary>The center of the right edge.</summary>
+    CenterRight,
+
+    /// <summary>The lower-left corner.</summary>
+    BottomLeft,
+
+    /// <summary>The center of the lower edge.</summary>
+    BottomCenter,
+
+    /// <summary>The lower-right corner.</summary>
+    BottomRight
+}
+
+internal static class WidgetAnchorExtensions
+{
+    internal static PointF GetPoint(
+        this WidgetAnchor anchor,
+        Rectangle bounds)
+    {
+        float centerX = bounds.Left + bounds.Width / 2f;
+        float centerY = bounds.Top + bounds.Height / 2f;
+
+        return anchor switch
+        {
+            WidgetAnchor.TopLeft => new PointF(bounds.Left, bounds.Top),
+            WidgetAnchor.TopCenter => new PointF(centerX, bounds.Top),
+            WidgetAnchor.TopRight => new PointF(bounds.Right, bounds.Top),
+            WidgetAnchor.CenterLeft => new PointF(bounds.Left, centerY),
+            WidgetAnchor.Center => new PointF(centerX, centerY),
+            WidgetAnchor.CenterRight => new PointF(bounds.Right, centerY),
+            WidgetAnchor.BottomLeft => new PointF(bounds.Left, bounds.Bottom),
+            WidgetAnchor.BottomCenter => new PointF(centerX, bounds.Bottom),
+            WidgetAnchor.BottomRight => new PointF(bounds.Right, bounds.Bottom),
+            _ => throw new ArgumentOutOfRangeException(nameof(anchor), anchor, null)
+        };
+    }
+}

--- a/Gondwana/Drawing/Direct/DirectComposite.cs
+++ b/Gondwana/Drawing/Direct/DirectComposite.cs
@@ -467,7 +467,7 @@ public class DirectComposite : IDirectCompositeChild, IDirectCompositeContainer
     /// This method uses the tick to calculate elapsed time and advance the movement controller.
     /// If the tick is less than or equal to the last processed tick, no update occurs.
     /// </remarks>
-    public void Update(long tick)
+    public virtual void Update(long tick)
     {
         if (_disposed || tick <= _lastTick)
             return;

--- a/Gondwana/Drawing/Direct/DirectRectangle.cs
+++ b/Gondwana/Drawing/Direct/DirectRectangle.cs
@@ -67,10 +67,47 @@ namespace Gondwana.Drawing.Direct;
 /// </example>
 public class DirectRectangle : DirectDrawingMovableBase
 {
+    /// <summary>
+    /// Defines how an image fills the rectangle interior.
+    /// </summary>
+    public enum ImageFillMode
+    {
+        /// <summary>Stretches the image to the full rectangle without preserving aspect ratio.</summary>
+        Stretch,
+
+        /// <summary>Fits the entire image inside the rectangle while preserving aspect ratio.</summary>
+        Fit,
+
+        /// <summary>Covers the rectangle while preserving aspect ratio and clips any overflow.</summary>
+        Fill,
+
+        /// <summary>Draws the image at native size, centered and clipped to the rectangle.</summary>
+        Center,
+
+        /// <summary>Uses the largest whole-number scale that fits, never scaling below native size.</summary>
+        PixelPerfect,
+
+        /// <summary>Repeats the image as tiles across the rectangle.</summary>
+        Repeat
+    }
+
     private readonly SKPaint _fillPaint;        // cached fill
     private readonly SKPaint _strokePaint;      // cached stroke
+    private readonly SKPaint _imagePaint = new()
+    {
+        IsAntialias = true,
+        FilterQuality = SKFilterQuality.Medium,
+        BlendMode = SKBlendMode.SrcOver
+    };
+
     private SKColor? _borderColor;              // optional distinct border color
     private SKShader? _fillShader;              // optional fill shader
+    private SKImage? _fillImage;
+    private SKBitmap? _fillBitmap;
+    private ImageFillMode _imageFillMode = ImageFillMode.Stretch;
+    private float _imageScale = 1f;
+    private SKPoint _imageOffsetPx;
+    private bool _resourcesDisposed;
 
     private bool _isFilled;
     private float _cornerRadius;
@@ -418,6 +455,7 @@ public class DirectRectangle : DirectDrawingMovableBase
         // apply to both paints
         _fillPaint.BlendMode = mode;
         _strokePaint.BlendMode = mode;
+        _imagePaint.BlendMode = mode;
         // no rebuild needed
         return this;
     }
@@ -608,6 +646,18 @@ public class DirectRectangle : DirectDrawingMovableBase
                                           SKPoint? offsetPx = null,
                                           SKFilterQuality filterQuality = SKFilterQuality.None)
     {
+        ArgumentNullException.ThrowIfNull(bitmap);
+
+        _fillImage = null;
+        _fillBitmap = null;
+
+        _fillPaint.Shader = null;
+        _fillShader?.Dispose();
+
+        scale = float.IsFinite(scale) && scale > 0f
+            ? scale
+            : throw new ArgumentOutOfRangeException(nameof(scale), "Pattern scale must be finite and greater than zero.");
+
         var m = SKMatrix.CreateScale(scale, scale);
         if (offsetPx is { } o)
             m = m.PostConcat(SKMatrix.CreateTranslation(o.X, o.Y));
@@ -618,6 +668,90 @@ public class DirectRectangle : DirectDrawingMovableBase
 
         // Ensure we're in filled mode for visibility
         _isFilled = true;
+        ForceRefresh();
+        return this;
+    }
+
+    /// <summary>
+    /// Fills the rectangle with a bitmap using the requested scaling or repeat behavior.
+    /// </summary>
+    /// <param name="bitmap">The bitmap to draw. The caller retains ownership.</param>
+    /// <param name="mode">How the bitmap is fitted to or repeated within the rectangle.</param>
+    /// <param name="scale">
+    /// A uniform scale applied in <see cref="ImageFillMode.Repeat"/> mode. Ignored by other modes.
+    /// </param>
+    /// <param name="offsetPx">An optional repeat-pattern offset relative to the rectangle's upper-left corner.</param>
+    /// <param name="filterQuality">The sampling quality used when the bitmap is scaled.</param>
+    /// <returns>This rectangle for fluent configuration.</returns>
+    /// <remarks>
+    /// The bitmap is clipped to the rectangle, including rounded corners. This method
+    /// automatically enables filled mode. Call <see cref="ClearFillImage"/> to return
+    /// to the configured solid-color fill.
+    /// </remarks>
+    public DirectRectangle SetFillImage(
+        SKBitmap bitmap,
+        ImageFillMode mode = ImageFillMode.Stretch,
+        float scale = 1f,
+        SKPoint? offsetPx = null,
+        SKFilterQuality filterQuality = SKFilterQuality.Medium)
+    {
+        ArgumentNullException.ThrowIfNull(bitmap);
+
+        SetFillImageCore(
+            image: null,
+            bitmap: bitmap,
+            mode: mode,
+            scale: scale,
+            offsetPx: offsetPx,
+            filterQuality: filterQuality);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Fills the rectangle with an image using the requested scaling or repeat behavior.
+    /// </summary>
+    /// <param name="image">The image to draw. The caller retains ownership.</param>
+    /// <param name="mode">How the image is fitted to or repeated within the rectangle.</param>
+    /// <param name="scale">
+    /// A uniform scale applied in <see cref="ImageFillMode.Repeat"/> mode. Ignored by other modes.
+    /// </param>
+    /// <param name="offsetPx">An optional repeat-pattern offset relative to the rectangle's upper-left corner.</param>
+    /// <param name="filterQuality">The sampling quality used when the image is scaled.</param>
+    /// <returns>This rectangle for fluent configuration.</returns>
+    /// <remarks>
+    /// The image is clipped to the rectangle, including rounded corners. This method
+    /// automatically enables filled mode. Call <see cref="ClearFillImage"/> to return
+    /// to the configured solid-color fill.
+    /// </remarks>
+    public DirectRectangle SetFillImage(
+        SKImage image,
+        ImageFillMode mode = ImageFillMode.Stretch,
+        float scale = 1f,
+        SKPoint? offsetPx = null,
+        SKFilterQuality filterQuality = SKFilterQuality.Medium)
+    {
+        ArgumentNullException.ThrowIfNull(image);
+
+        SetFillImageCore(
+            image: image,
+            bitmap: null,
+            mode: mode,
+            scale: scale,
+            offsetPx: offsetPx,
+            filterQuality: filterQuality);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Removes the current bitmap or image fill and returns to solid-color filling.
+    /// </summary>
+    /// <returns>This rectangle for fluent configuration.</returns>
+    public DirectRectangle ClearFillImage()
+    {
+        _fillImage = null;
+        _fillBitmap = null;
         ForceRefresh();
         return this;
     }
@@ -637,9 +771,9 @@ public class DirectRectangle : DirectDrawingMovableBase
     /// </remarks>
     public DirectRectangle ClearFillPattern()
     {
+        _fillPaint.Shader = null;
         _fillShader?.Dispose();
         _fillShader = null;
-        _fillPaint.Shader = null;
         ForceRefresh();
         return this;
     }
@@ -791,10 +925,18 @@ public class DirectRectangle : DirectDrawingMovableBase
         // 3) Draw fill (unmodified rect)
         if (_isFilled)
         {
-            if (_cornerRadius > 0)
+            if (_fillImage is not null || _fillBitmap is not null)
+            {
+                DrawImageFill(canvas, fillRect);
+            }
+            else if (_cornerRadius > 0)
+            {
                 canvas.DrawRoundRect(fillRect, strokeCornerRadius, strokeCornerRadius, _fillPaint);
+            }
             else
+            {
                 canvas.DrawRect(fillRect, _fillPaint);
+            }
         }
 
         // 4) Draw stroke on its aligned rect (pure/opaque so it stays white)
@@ -825,6 +967,212 @@ public class DirectRectangle : DirectDrawingMovableBase
             _strokePaint.StrokeJoin = SKStrokeJoin.Round;
             _strokePaint.StrokeCap = SKStrokeCap.Round;
         }
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && !_resourcesDisposed)
+        {
+            _resourcesDisposed = true;
+            _fillPaint.Shader = null;
+            _fillShader?.Dispose();
+            _fillShader = null;
+            _fillPaint.Dispose();
+            _strokePaint.Dispose();
+            _imagePaint.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private void SetFillImageCore(
+        SKImage? image,
+        SKBitmap? bitmap,
+        ImageFillMode mode,
+        float scale,
+        SKPoint? offsetPx,
+        SKFilterQuality filterQuality)
+    {
+        if (!float.IsFinite(scale) || scale <= 0f)
+            throw new ArgumentOutOfRangeException(nameof(scale), "Image scale must be finite and greater than zero.");
+
+        if (!Enum.IsDefined(mode))
+            throw new ArgumentOutOfRangeException(nameof(mode));
+
+        _fillPaint.Shader = null;
+        _fillShader?.Dispose();
+        _fillShader = null;
+
+        _fillImage = image;
+        _fillBitmap = bitmap;
+        _imageFillMode = mode;
+        _imageScale = scale;
+        _imageOffsetPx = offsetPx ?? SKPoint.Empty;
+        _imagePaint.FilterQuality = filterQuality;
+        _isFilled = true;
+
+        ForceRefresh();
+    }
+
+    private void DrawImageFill(
+        SKCanvas canvas,
+        SKRect fillRect)
+    {
+        SKImage? image = _fillImage;
+        bool disposeImage = false;
+
+        if (image is null && _fillBitmap is not null)
+        {
+            image = SKImage.FromBitmap(_fillBitmap);
+            disposeImage = true;
+        }
+
+        if (image is null || image.Width <= 0 || image.Height <= 0)
+            return;
+
+        canvas.Save();
+
+        try
+        {
+            using var clipPath = new SKPath();
+
+            if (_cornerRadius > 0f)
+                clipPath.AddRoundRect(fillRect, _cornerRadius, _cornerRadius);
+            else
+                clipPath.AddRect(fillRect);
+
+            canvas.ClipPath(
+                clipPath,
+                SKClipOperation.Intersect,
+                antialias: _cornerRadius > 0f);
+
+            var source = new SKRect(
+                0f,
+                0f,
+                image.Width,
+                image.Height);
+
+            if (_imageFillMode == ImageFillMode.Repeat)
+            {
+                DrawRepeatedImage(
+                    canvas,
+                    image,
+                    source,
+                    fillRect);
+            }
+            else
+            {
+                SKRect destination = ComputeImageDestination(
+                    fillRect,
+                    source,
+                    _imageFillMode);
+
+                canvas.DrawImage(
+                    image,
+                    source,
+                    destination,
+                    _imagePaint);
+            }
+        }
+        finally
+        {
+            canvas.Restore();
+
+            if (disposeImage)
+                image.Dispose();
+        }
+    }
+
+    private void DrawRepeatedImage(
+        SKCanvas canvas,
+        SKImage image,
+        SKRect source,
+        SKRect fillRect)
+    {
+        float tileWidth = image.Width * _imageScale;
+        float tileHeight = image.Height * _imageScale;
+
+        float offsetX = PositiveModulo(_imageOffsetPx.X, tileWidth);
+        float offsetY = PositiveModulo(_imageOffsetPx.Y, tileHeight);
+
+        float startX = fillRect.Left + offsetX;
+        float startY = fillRect.Top + offsetY;
+
+        if (startX > fillRect.Left)
+            startX -= tileWidth;
+
+        if (startY > fillRect.Top)
+            startY -= tileHeight;
+
+        for (float y = startY; y < fillRect.Bottom; y += tileHeight)
+        {
+            for (float x = startX; x < fillRect.Right; x += tileWidth)
+            {
+                canvas.DrawImage(
+                    image,
+                    source,
+                    new SKRect(
+                        x,
+                        y,
+                        x + tileWidth,
+                        y + tileHeight),
+                    _imagePaint);
+            }
+        }
+    }
+
+    private static SKRect ComputeImageDestination(
+        SKRect bounds,
+        SKRect source,
+        ImageFillMode mode)
+    {
+        if (mode == ImageFillMode.Stretch)
+            return bounds;
+
+        if (mode == ImageFillMode.Center)
+        {
+            float x = bounds.MidX - source.Width * 0.5f;
+            float y = bounds.MidY - source.Height * 0.5f;
+
+            return new SKRect(
+                x,
+                y,
+                x + source.Width,
+                y + source.Height);
+        }
+
+        float scaleX = bounds.Width / source.Width;
+        float scaleY = bounds.Height / source.Height;
+
+        float scale = mode switch
+        {
+            ImageFillMode.Fit => MathF.Min(scaleX, scaleY),
+            ImageFillMode.Fill => MathF.Max(scaleX, scaleY),
+            ImageFillMode.PixelPerfect => MathF.Max(
+                1f,
+                MathF.Floor(MathF.Min(scaleX, scaleY))),
+            _ => 1f
+        };
+
+        float width = source.Width * scale;
+        float height = source.Height * scale;
+        float left = bounds.MidX - width * 0.5f;
+        float top = bounds.MidY - height * 0.5f;
+
+        return new SKRect(
+            left,
+            top,
+            left + width,
+            top + height);
+    }
+
+    private static float PositiveModulo(float value, float modulus)
+    {
+        float remainder = value % modulus;
+        return remainder < 0f
+            ? remainder + modulus
+            : remainder;
     }
 
     /// <summary>

--- a/Gondwana/Drawing/Direct/DirectRectangle.cs
+++ b/Gondwana/Drawing/Direct/DirectRectangle.cs
@@ -648,12 +648,6 @@ public class DirectRectangle : DirectDrawingMovableBase
     {
         ArgumentNullException.ThrowIfNull(bitmap);
 
-        _fillImage = null;
-        _fillBitmap = null;
-
-        _fillPaint.Shader = null;
-        _fillShader?.Dispose();
-
         scale = float.IsFinite(scale) && scale > 0f
             ? scale
             : throw new ArgumentOutOfRangeException(nameof(scale), "Pattern scale must be finite and greater than zero.");
@@ -662,7 +656,15 @@ public class DirectRectangle : DirectDrawingMovableBase
         if (offsetPx is { } o)
             m = m.PostConcat(SKMatrix.CreateTranslation(o.X, o.Y));
 
-        _fillShader = SKShader.CreateBitmap(bitmap, tileX, tileY, m);
+        SKShader newShader = SKShader.CreateBitmap(bitmap, tileX, tileY, m);
+
+        _fillPaint.Shader = null;
+        _fillShader?.Dispose();
+        _fillShader = newShader;
+
+        _fillImage = null;
+        _fillBitmap = null;
+
         _fillPaint.Shader = _fillShader;
         _fillPaint.FilterQuality = filterQuality; // or Low/Medium/High
 
@@ -1020,15 +1022,12 @@ public class DirectRectangle : DirectDrawingMovableBase
         SKRect fillRect)
     {
         SKImage? image = _fillImage;
-        bool disposeImage = false;
+        SKBitmap? bitmap = _fillBitmap;
 
-        if (image is null && _fillBitmap is not null)
-        {
-            image = SKImage.FromBitmap(_fillBitmap);
-            disposeImage = true;
-        }
+        int sourceWidth = image?.Width ?? bitmap?.Width ?? 0;
+        int sourceHeight = image?.Height ?? bitmap?.Height ?? 0;
 
-        if (image is null || image.Width <= 0 || image.Height <= 0)
+        if (sourceWidth <= 0 || sourceHeight <= 0)
             return;
 
         canvas.Save();
@@ -1050,16 +1049,27 @@ public class DirectRectangle : DirectDrawingMovableBase
             var source = new SKRect(
                 0f,
                 0f,
-                image.Width,
-                image.Height);
+                sourceWidth,
+                sourceHeight);
 
             if (_imageFillMode == ImageFillMode.Repeat)
             {
-                DrawRepeatedImage(
-                    canvas,
-                    image,
-                    source,
-                    fillRect);
+                if (image is not null)
+                {
+                    DrawRepeatedImage(
+                        canvas,
+                        image,
+                        source,
+                        fillRect);
+                }
+                else
+                {
+                    DrawRepeatedBitmap(
+                        canvas,
+                        bitmap!,
+                        source,
+                        fillRect);
+                }
             }
             else
             {
@@ -1068,19 +1078,27 @@ public class DirectRectangle : DirectDrawingMovableBase
                     source,
                     _imageFillMode);
 
-                canvas.DrawImage(
-                    image,
-                    source,
-                    destination,
-                    _imagePaint);
+                if (image is not null)
+                {
+                    canvas.DrawImage(
+                        image,
+                        source,
+                        destination,
+                        _imagePaint);
+                }
+                else
+                {
+                    canvas.DrawBitmap(
+                        bitmap!,
+                        source,
+                        destination,
+                        _imagePaint);
+                }
             }
         }
         finally
         {
             canvas.Restore();
-
-            if (disposeImage)
-                image.Dispose();
         }
     }
 
@@ -1111,6 +1129,44 @@ public class DirectRectangle : DirectDrawingMovableBase
             {
                 canvas.DrawImage(
                     image,
+                    source,
+                    new SKRect(
+                        x,
+                        y,
+                        x + tileWidth,
+                        y + tileHeight),
+                    _imagePaint);
+            }
+        }
+    }
+
+    private void DrawRepeatedBitmap(
+        SKCanvas canvas,
+        SKBitmap bitmap,
+        SKRect source,
+        SKRect fillRect)
+    {
+        float tileWidth = bitmap.Width * _imageScale;
+        float tileHeight = bitmap.Height * _imageScale;
+
+        float offsetX = PositiveModulo(_imageOffsetPx.X, tileWidth);
+        float offsetY = PositiveModulo(_imageOffsetPx.Y, tileHeight);
+
+        float startX = fillRect.Left + offsetX;
+        float startY = fillRect.Top + offsetY;
+
+        if (startX > fillRect.Left)
+            startX -= tileWidth;
+
+        if (startY > fillRect.Top)
+            startY -= tileHeight;
+
+        for (float y = startY; y < fillRect.Bottom; y += tileHeight)
+        {
+            for (float x = startX; x < fillRect.Right; x += tileWidth)
+            {
+                canvas.DrawBitmap(
+                    bitmap,
                     source,
                     new SKRect(
                         x,

--- a/Testing/Gondwana.Tests/Drawing/Direct/DirectRectangleImageFillTests.cs
+++ b/Testing/Gondwana.Tests/Drawing/Direct/DirectRectangleImageFillTests.cs
@@ -66,6 +66,62 @@ public sealed class DirectRectangleImageFillTests
         Assert.Equal(SKColors.Blue, result.GetPixel(7, 2));
     }
 
+    [Fact]
+    public void SetFillPattern_InvalidScalePreservesExistingPattern()
+    {
+        using var host = new TestRenderSurfaceHost();
+        View view = AddView(host, new Rectangle(0, 0, 6, 4));
+        using var source = CreateTwoColorBitmap();
+        using var backbuffer = new BitmapBackbuffer(6, 4);
+        using var rectangle = new DirectRectangle(
+                Color.White,
+                host,
+                view,
+                new Rectangle(0, 0, 6, 4))
+            .SetStrokeWidth(0f)
+            .SetFillPattern(source);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            rectangle.SetFillPattern(source, scale: 0f));
+
+        rectangle.Draw(backbuffer, new RectangleF(0, 0, 6, 4));
+
+        using SKImage snapshot = backbuffer.Snapshot();
+        using SKBitmap result = SKBitmap.FromImage(snapshot);
+
+        Assert.Equal(SKColors.Red, result.GetPixel(0, 0));
+        Assert.Equal(SKColors.Blue, result.GetPixel(1, 0));
+        Assert.Equal(SKColors.Red, result.GetPixel(2, 0));
+    }
+
+    [Fact]
+    public void SetFillImage_ImageSourceStillRenders()
+    {
+        using var host = new TestRenderSurfaceHost();
+        View view = AddView(host, new Rectangle(0, 0, 8, 4));
+        using var bitmap = CreateTwoColorBitmap();
+        using var source = SKImage.FromBitmap(bitmap);
+        using var backbuffer = new BitmapBackbuffer(8, 4);
+        using var rectangle = new DirectRectangle(
+                Color.White,
+                host,
+                view,
+                new Rectangle(0, 0, 8, 4))
+            .SetStrokeWidth(0f)
+            .SetFillImage(
+                source,
+                DirectRectangle.ImageFillMode.Stretch,
+                filterQuality: SKFilterQuality.None);
+
+        rectangle.Draw(backbuffer, new RectangleF(0, 0, 8, 4));
+
+        using SKImage snapshot = backbuffer.Snapshot();
+        using SKBitmap result = SKBitmap.FromImage(snapshot);
+
+        Assert.Equal(SKColors.Red, result.GetPixel(0, 2));
+        Assert.Equal(SKColors.Blue, result.GetPixel(7, 2));
+    }
+
     private static SKBitmap CreateTwoColorBitmap()
     {
         var bitmap = new SKBitmap(

--- a/Testing/Gondwana.Tests/Drawing/Direct/DirectRectangleImageFillTests.cs
+++ b/Testing/Gondwana.Tests/Drawing/Direct/DirectRectangleImageFillTests.cs
@@ -1,0 +1,92 @@
+using System.Drawing;
+using Gondwana.Drawing.Direct;
+using Gondwana.Rendering.Backbuffers;
+using Gondwana.Rendering.Views;
+using SkiaSharp;
+
+namespace Gondwana.Tests.Drawing.Direct;
+
+public sealed class DirectRectangleImageFillTests
+{
+    [Fact]
+    public void SetFillImage_RepeatTilesImageAcrossRectangle()
+    {
+        using var host = new TestRenderSurfaceHost();
+        View view = AddView(host, new Rectangle(0, 0, 6, 4));
+        using var source = CreateTwoColorBitmap();
+        using var backbuffer = new BitmapBackbuffer(6, 4);
+        using var rectangle = new DirectRectangle(
+                Color.White,
+                host,
+                view,
+                new Rectangle(0, 0, 6, 4))
+            .SetStrokeWidth(0f)
+            .SetFillImage(
+                source,
+                DirectRectangle.ImageFillMode.Repeat,
+                filterQuality: SKFilterQuality.None);
+
+        rectangle.Draw(backbuffer, new RectangleF(0, 0, 6, 4));
+
+        using SKImage snapshot = backbuffer.Snapshot();
+        using SKBitmap result = SKBitmap.FromImage(snapshot);
+
+        Assert.Equal(SKColors.Red, result.GetPixel(0, 0));
+        Assert.Equal(SKColors.Blue, result.GetPixel(1, 0));
+        Assert.Equal(SKColors.Red, result.GetPixel(2, 0));
+        Assert.Equal(SKColors.Blue, result.GetPixel(5, 3));
+    }
+
+    [Fact]
+    public void SetFillImage_StretchFillsRectangleWithoutRepeating()
+    {
+        using var host = new TestRenderSurfaceHost();
+        View view = AddView(host, new Rectangle(0, 0, 8, 4));
+        using var source = CreateTwoColorBitmap();
+        using var backbuffer = new BitmapBackbuffer(8, 4);
+        using var rectangle = new DirectRectangle(
+                Color.White,
+                host,
+                view,
+                new Rectangle(0, 0, 8, 4))
+            .SetStrokeWidth(0f)
+            .SetFillImage(
+                source,
+                DirectRectangle.ImageFillMode.Stretch,
+                filterQuality: SKFilterQuality.None);
+
+        rectangle.Draw(backbuffer, new RectangleF(0, 0, 8, 4));
+
+        using SKImage snapshot = backbuffer.Snapshot();
+        using SKBitmap result = SKBitmap.FromImage(snapshot);
+
+        Assert.Equal(SKColors.Red, result.GetPixel(0, 2));
+        Assert.Equal(SKColors.Red, result.GetPixel(3, 2));
+        Assert.Equal(SKColors.Blue, result.GetPixel(4, 2));
+        Assert.Equal(SKColors.Blue, result.GetPixel(7, 2));
+    }
+
+    private static SKBitmap CreateTwoColorBitmap()
+    {
+        var bitmap = new SKBitmap(
+            new SKImageInfo(
+                2,
+                1,
+                SKColorType.Bgra8888,
+                SKAlphaType.Premul));
+
+        bitmap.SetPixel(0, 0, SKColors.Red);
+        bitmap.SetPixel(1, 0, SKColors.Blue);
+        return bitmap;
+    }
+
+    private static View AddView(
+        TestRenderSurfaceHost host,
+        Rectangle bounds)
+    {
+        host.ViewManager.AddView(bounds, zOrder: 0);
+
+        return host.ViewManager.Views.Single(view =>
+            view.Viewport.TargetRectPx == bounds);
+    }
+}

--- a/Testing/Gondwana.Tests/Widgets/TransientOverlayWidgetTests.cs
+++ b/Testing/Gondwana.Tests/Widgets/TransientOverlayWidgetTests.cs
@@ -1,0 +1,178 @@
+using System.Drawing;
+using System.Numerics;
+using Gondwana.Drawing.Coordinates;
+using Gondwana.Drawing.Direct;
+using Gondwana.Rendering.Views;
+using Gondwana.Scenes;
+using Gondwana.Timers;
+using Gondwana.Widgets;
+using Gondwana.Widgets.Overlays;
+
+namespace Gondwana.Tests.Widgets;
+
+public sealed class TransientOverlayWidgetTests
+{
+    [Fact]
+    public void Toast_AnchorsInsideViewAndSlidesFromConfiguredEdge()
+    {
+        using var host = new TestRenderSurfaceHost();
+        View view = AddView(
+            host,
+            new Rectangle(100, 50, 400, 300));
+
+        using var toast = new ToastWidget(
+            host,
+            view,
+            new Size(120, 60),
+            "Saved",
+            WidgetAnchor.TopRight,
+            marginPx: 10)
+        {
+            HoldDurationSec = null,
+            DisposeOnDismiss = false,
+            SlideOrigin = ToastSlideOrigin.Right,
+            SourceOffsetPx = 8,
+            TransitionDurationSec = 0.25f
+        };
+
+        toast.ShowToast();
+
+        Assert.Equal(new Rectangle(370, 60, 120, 60), toast.TargetBounds);
+        Assert.Equal(new Vector2(508, 60), toast.GetPosition());
+        Assert.Equal(ToastState.Entering, toast.CurrentState);
+
+        long entranceTick =
+            HighResTimer.GetCurrentTick()
+            + HighResTimer.TicksPerSecond;
+
+        toast.Update(entranceTick);
+
+        Assert.Equal(new Vector2(370, 60), toast.GetPosition());
+        Assert.Equal(ToastState.Holding, toast.CurrentState);
+
+        toast.Dismiss();
+        toast.Update(entranceTick + HighResTimer.TicksPerSecond);
+
+        Assert.Equal(ToastState.Hidden, toast.CurrentState);
+        Assert.False(toast.Visible);
+    }
+
+    [Fact]
+    public void Toast_FadeCanRemainUntilManuallyDismissed()
+    {
+        using var host = new TestRenderSurfaceHost();
+        View view = AddView(host, new Rectangle(0, 0, 640, 480));
+
+        using var toast = new ToastWidget(
+            host,
+            view,
+            new Rectangle(20, 30, 240, 64),
+            "Waiting")
+        {
+            Transition = ToastTransition.Fade,
+            TransitionDurationSec = 0f,
+            HoldDurationSec = null,
+            AnimateDismissal = false,
+            DisposeOnDismiss = false
+        };
+
+        toast.ShowToast();
+
+        Assert.Equal(ToastState.Holding, toast.CurrentState);
+        Assert.True(toast.Visible);
+
+        toast.Dismiss();
+
+        Assert.Equal(ToastState.Hidden, toast.CurrentState);
+        Assert.False(toast.Visible);
+    }
+
+    [Fact]
+    public void Popup_ResolvesProjectionAwareGridSourceWhenShown()
+    {
+        using var host = new TestRenderSurfaceHost();
+
+        SceneLayer layer = host.Scene.AddLayer(
+            columnCount: 8,
+            rowCount: 8,
+            width: 64,
+            height: 32,
+            zOrder: 0,
+            parallax: 1f,
+            coordinateSystem: CoordinateSystemTypes.IsometricRhombic);
+
+        SceneLayerTile source = layer[2, 3]!;
+        Rectangle sourceBounds = source.DrawLocationWorld;
+
+        using var popup = new PopupWidget(
+                host,
+                layer,
+                new Rectangle(0, 0, 80, 30),
+                "+100")
+            .BindTo(
+                layer,
+                new Point(2, 3),
+                WidgetAnchor.TopCenter,
+                new Point(4, -6));
+
+        popup.FadeInSec = 0f;
+        popup.FadeOutSec = 0f;
+        popup.DisposeOnComplete = false;
+        popup.VelocityPxPerSec = Vector2.Zero;
+
+        popup.ShowPopup();
+
+        var expected = new Vector2(
+            sourceBounds.Left + sourceBounds.Width / 2f - 40f + 4f,
+            sourceBounds.Top - 15f - 6f);
+
+        Assert.Equal(new Point(2, 3), popup.SourceGridLocation);
+        Assert.Same(source, popup.SourceTile);
+        Assert.Equal(expected, popup.GetPosition());
+    }
+
+    [Fact]
+    public void Popup_AppliesMovementAndCompletesAfterLifetime()
+    {
+        using var host = new TestRenderSurfaceHost();
+        View view = AddView(host, new Rectangle(0, 0, 640, 480));
+
+        using var popup = new PopupWidget(
+            host,
+            view,
+            new Rectangle(100, 100, 80, 30),
+            "-12")
+        {
+            LifetimeSec = 0.5f,
+            FadeInSec = 0f,
+            FadeOutSec = 0f,
+            VelocityPxPerSec = new Vector2(20f, -40f),
+            DisposeOnComplete = false
+        };
+
+        popup.ShowPopup();
+
+        long movementTick =
+            HighResTimer.GetCurrentTick()
+            + HighResTimer.TicksPerSecond / 4;
+
+        popup.Update(movementTick);
+
+        Assert.True(popup.GetPosition().X > 100f);
+        Assert.True(popup.GetPosition().Y < 100f);
+
+        popup.Update(movementTick + HighResTimer.TicksPerSecond);
+
+        Assert.False(popup.Visible);
+    }
+
+    private static View AddView(
+        TestRenderSurfaceHost host,
+        Rectangle bounds)
+    {
+        host.ViewManager.AddView(bounds, zOrder: 0);
+
+        return host.ViewManager.Views.Single(view =>
+            view.Viewport.TargetRectPx == bounds);
+    }
+}


### PR DESCRIPTION
- Add toast and popup overlay widgets for transient in-game UI messages.
- Introduce widget anchoring to position overlays relative to screen edges.
- Expand DirectRectangle fill/draw behavior with minor DirectDrawing updates.
- Add tests and README coverage for the new widget and rendering behavior.